### PR TITLE
Fix migration from outdated versions

### DIFF
--- a/appinfo/preupdate.php
+++ b/appinfo/preupdate.php
@@ -9,7 +9,7 @@ if (version_compare($installedVersion, '0.6', '<')) {
 		$deleteQuery->execute(array($row['fileid']));
 	}
 }
-if (version_compare($installedVersion, '0.6.1', '<')) {
+if (version_compare($installedVersion, '0.6.1', '<') && version_compare($installedVersion, '0.5', '>=')) {
 	$alterQuery = OCP\DB::prepare( 'ALTER TABLE `*PREFIX*files_antivirus_status` RENAME TO `*PREFIX*files_avir_status`' );
 	$alterQuery->execute();
 }


### PR DESCRIPTION
Ref https://github.com/owncloud/apps/issues/2075
`oc_files_antivirus_status` was introduced in v0.5 so there is no chance to rename it for all versions prior to this one. 