### PR TITLE
Bugfix for #82, and fixes #69 

### DIFF
--- a/lib/backgroundscanner.php
+++ b/lib/backgroundscanner.php
@@ -59,7 +59,8 @@ class BackgroundScanner {
 			.' WHERE `mimetype` != ?'
 			.' AND (`*PREFIX*storages`.`id` LIKE ? OR `*PREFIX*storages`.`id` LIKE ?)'
 			.' AND (`*PREFIX*files_antivirus`.`fileid` IS NULL OR `mtime` > `check_time`)'
-			.' AND `path` LIKE ?';
+			.' AND `path` LIKE ?'
+			.' AND `*PREFIX*filecache`.`size` != 0';
 		$stmt = \OCP\DB::prepare($sql, 5);
 		try {
 			$result = $stmt->execute(array($dirMimetypeId, 'local::%', 'home::%', 'files/%'));
@@ -77,9 +78,6 @@ class BackgroundScanner {
 			$path = $view->getPath($row['fileid']);
 			if (!is_null($path)) {
 				$item = new Item($this->l10n, $view, $path, $row['fileid']);
-				if (!$item->isValid()){
-					continue;
-				}
 				$scanner = $this->scannerFactory->getScanner();
 				$status = $scanner->scan($item);					
 				$status->dispatch($item, true);


### PR DESCRIPTION
The proposed patch (#82) for bug #69 will repeatedly (every cronjob) select the empty files from the filecache, and then skip over them. Their fileid's will never be added to the files_antivirus table, so they will always be selected. Once there are more than 5 empty files, the background scanner will select those 5 as a result of the JOIN and LEFT JOIN, and will skip them all. This will leave the remainder of the files on the server unprotected.

A better solution is to only consider files with non-zero sizes in the first place.