### PR TITLE
updated info.xml for v9 support

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,6 +11,7 @@ For this app to be effective, the ClamAV virus definitions should be kept up to 
 	<licence>AGPL</licence>
 	<author>Manuel Delgado, Bart Visscher, thinksilicon.de, Victor Dubiniuk</author>
 	<requiremin>8</requiremin>
+	<version>0.8.0.0</version>
 	<types>
 		<filesystem/>
 	</types>


### PR DESCRIPTION
Starting with 9.1, the "appinfo/version" will not be supported any more.
The version number is moved to "appinfo/info.xml" 
as per https://github.com/owncloud/core/issues/22905