### PR TITLE
Add AVMaxFileSize config option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
 
   # Run phpunit tests
   - cd tests
+  - php avirserver.php &
   - phpunit --configuration phpunit.xml
 
   # Create coverage report

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -57,6 +57,7 @@ class Application extends App {
 			return new BackgroundScanner(
 				$c->query('ScannerFactory'),
 				$c->query('L10N'),
+				$c->query('AppConfig'),
 				$c->getServer()->getRootFolder(),
 				$c->getServer()->getUserSession()
 			);

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -53,10 +53,11 @@ class SettingsController extends Controller {
 	 * @param int $avChunkSize - Size of one portion
 	 * @param string $avPath - path to antivirus executable (Executable mode)
 	 * @param string $avInfectedAction - action performed on infected files
+	 * @param $avStreamMaxLength - reopen socket after bytes
 	 * @param int $avMaxFileSize - file size limit
 	 * @return JSONResponse
 	 */
-	public function save($avMode, $avSocket, $avHost, $avPort, $avCmdOptions, $avChunkSize, $avPath, $avInfectedAction, $avMaxFileSize) {
+	public function save($avMode, $avSocket, $avHost, $avPort, $avCmdOptions, $avChunkSize, $avPath, $avInfectedAction, $avStreamMaxLength, $avMaxFileSize) {
 		$this->settings->setAvMode($avMode);
 		$this->settings->setAvSocket($avSocket);
 		$this->settings->setAvHost($avHost);
@@ -65,6 +66,7 @@ class SettingsController extends Controller {
 		$this->settings->setAvChunkSize($avChunkSize);
 		$this->settings->setAvPath($avPath);
 		$this->settings->setAvInfectedAction($avInfectedAction);
+		$this->settings->setAvStreamMaxLength($avStreamMaxLength);
 		$this->settings->setAvMaxFileSize($avMaxFileSize);
 		
 		return new JSONResponse(

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -41,9 +41,10 @@ class SettingsController extends Controller {
 		$data = $this->settings->getAllValues();
 		return new TemplateResponse('files_antivirus', 'settings', $data, 'blank');
 	}
-	
+
 	/**
 	 * Save Parameters
+	 *
 	 * @param string $avMode - antivirus mode
 	 * @param string $avSocket - path to socket (Socket mode)
 	 * @param string $avHost - antivirus url
@@ -52,9 +53,10 @@ class SettingsController extends Controller {
 	 * @param int $avChunkSize - Size of one portion
 	 * @param string $avPath - path to antivirus executable (Executable mode)
 	 * @param string $avInfectedAction - action performed on infected files
+	 * @param int $avMaxFileSize - file size limit
 	 * @return JSONResponse
 	 */
-	public function save($avMode, $avSocket, $avHost, $avPort, $avCmdOptions, $avChunkSize, $avPath, $avInfectedAction) {
+	public function save($avMode, $avSocket, $avHost, $avPort, $avCmdOptions, $avChunkSize, $avPath, $avInfectedAction, $avMaxFileSize) {
 		$this->settings->setAvMode($avMode);
 		$this->settings->setAvSocket($avSocket);
 		$this->settings->setAvHost($avHost);
@@ -63,6 +65,7 @@ class SettingsController extends Controller {
 		$this->settings->setAvChunkSize($avChunkSize);
 		$this->settings->setAvPath($avPath);
 		$this->settings->setAvInfectedAction($avInfectedAction);
+		$this->settings->setAvMaxFileSize($avMaxFileSize);
 		
 		return new JSONResponse(
 			array('data' =>

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -50,20 +50,18 @@ class SettingsController extends Controller {
 	 * @param string $avHost - antivirus url
 	 * @param int $avPort - port
 	 * @param string $avCmdOptions - extra command line options
-	 * @param int $avChunkSize - Size of one portion
 	 * @param string $avPath - path to antivirus executable (Executable mode)
 	 * @param string $avInfectedAction - action performed on infected files
 	 * @param $avStreamMaxLength - reopen socket after bytes
 	 * @param int $avMaxFileSize - file size limit
 	 * @return JSONResponse
 	 */
-	public function save($avMode, $avSocket, $avHost, $avPort, $avCmdOptions, $avChunkSize, $avPath, $avInfectedAction, $avStreamMaxLength, $avMaxFileSize) {
+	public function save($avMode, $avSocket, $avHost, $avPort, $avCmdOptions, $avPath, $avInfectedAction, $avStreamMaxLength, $avMaxFileSize) {
 		$this->settings->setAvMode($avMode);
 		$this->settings->setAvSocket($avSocket);
 		$this->settings->setAvHost($avHost);
 		$this->settings->setAvPort($avPort);
 		$this->settings->setAvCmdOptions($avCmdOptions);
-		$this->settings->setAvChunkSize($avChunkSize);
 		$this->settings->setAvPath($avPath);
 		$this->settings->setAvInfectedAction($avInfectedAction);
 		$this->settings->setAvStreamMaxLength($avStreamMaxLength);

--- a/css/settings.css
+++ b/css/settings.css
@@ -11,6 +11,10 @@
 	text-align: right;
 }
 
+.section-antivirus .a-left{
+	text-align: left;
+}
+
 .shaded{
 	opacity: .3;
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -131,19 +131,13 @@ var antivirusSettings = antivirusSettings || {
 
 function av_mode_show_options(str){
 	if ( str == 'daemon'){
-		$('p.av_socket').hide('slow');
-		$('p.av_host').show('slow');
-		$('p.av_port').show('slow');
-		$('p.av_path').hide('slow');
+		$('p.av_socket, p.av_path').hide('slow');
+		$('p.av_host, p.av_port,  p.av_stream_max_length').show('slow');
 	} else if ( str == 'socket' ) {
-		$('p.av_socket').show('slow');
-		$('p.av_path').hide('slow');
-		$('p.av_host').hide('slow');
-		$('p.av_port').hide('slow');
-        } else if (str == 'executable'){
-		$('p.av_socket').hide('slow');
-		$('p.av_host').hide('slow');
-		$('p.av_port').hide('slow');
+		$('p.av_socket, p.av_stream_max_length').show('slow');
+		$('p.av_path, p.av_host, p.av_port').hide('slow');
+	} else if (str == 'executable'){
+		$('p.av_socket, p.av_host, p.av_port, p.av_stream_max_length').hide('slow');
 		$('p.av_path').show('slow');
 	}
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -132,12 +132,12 @@ var antivirusSettings = antivirusSettings || {
 function av_mode_show_options(str){
 	if ( str == 'daemon'){
 		$('p.av_socket, p.av_path').hide('slow');
-		$('p.av_host, p.av_port,  p.av_stream_max_length').show('slow');
+		$('p.av_host, p.av_port').show('slow');
 	} else if ( str == 'socket' ) {
-		$('p.av_socket, p.av_stream_max_length').show('slow');
+		$('p.av_socket').show('slow');
 		$('p.av_path, p.av_host, p.av_port').hide('slow');
 	} else if (str == 'executable'){
-		$('p.av_socket, p.av_host, p.av_port, p.av_stream_max_length').hide('slow');
+		$('p.av_socket, p.av_host, p.av_port').hide('slow');
 		$('p.av_path').show('slow');
 	}
 }

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -15,6 +15,7 @@ use \OCP\IConfig;
 	 * @method string getAvSocket()
 	 * @method string getAvHost()
 	 * @method int getAvPort()
+	 * @method int getAvMaxFileSize()
 	 * @method string getAvCmdOptions()
 	 * @method int getAvChunkSize()
 	 * @method string getAvPath()
@@ -24,6 +25,7 @@ use \OCP\IConfig;
 	 * @method null setAvSocket(string $avsocket)
 	 * @method null setAvHost(string $avHost)
 	 * @method null setAvPort(int $avPort)
+	 * @method null setAvMaxFileSize(int $fileSize)
 	 * @method null setAvCmdOptions(string $avCmdOptions)
 	 * @method null setAvChunkSize(int $chunkSize)
 	 * @method null setAvPath(string $avPath)
@@ -32,9 +34,11 @@ use \OCP\IConfig;
 
 class AppConfig {
 	private $appName = 'files_antivirus';
+
+	/** @var IConfig  */
 	private $config;
 
-	private $defaults = array(
+	private $defaults = [
 		'av_mode' => 'executable',
 		'av_socket' => '/var/run/clamav/clamd.ctl',
 		'av_host' => '',
@@ -42,9 +46,15 @@ class AppConfig {
 		'av_cmd_options' => '',
 		'av_chunk_size' => '1024',
 		'av_path' => '/usr/bin/clamscan',
+		'av_max_file_size' => -1,
 		'av_infected_action' => 'only_log',
-	);
-	
+	];
+
+	/**
+	 * AppConfig constructor.
+	 *
+	 * @param IConfig $config
+	 */
 	public function __construct(IConfig $config) {
 		$this->config = $config;
 	}
@@ -56,7 +66,7 @@ class AppConfig {
 	public function getCmdline(){
 		$avCmdOptions = $this->getAvCmdOptions();
 		
-		$shellArgs = array();
+		$shellArgs = [];
 		if ($avCmdOptions) {
 			$shellArgs = explode(',', $avCmdOptions);
 				$shellArgs = array_map(function($i){
@@ -103,7 +113,7 @@ class AppConfig {
 	 * @param string $value
 	 * @return string
 	 */
-	public function setAppvalue($key, $value) {
+	public function setAppValue($key, $value) {
 		return $this->config->setAppValue($this->appName, $key, $value);
 	}
 	
@@ -115,7 +125,7 @@ class AppConfig {
 	 */
 	protected function setter($key, $args) {
 		if (array_key_exists($key, $this->defaults)) {
-			$this->setAppvalue($key, $args[0]);
+			$this->setAppValue($key, $args[0]);
 		} else {
 			throw new \BadFunctionCallException($key . ' is not a valid key');
 		}

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -18,10 +18,9 @@ use \OCP\IConfig;
 	 * @method int getAvMaxFileSize()
 	 * @method int getAvStreamMaxLength()
 	 * @method string getAvCmdOptions()
-	 * @method int getAvChunkSize()
 	 * @method string getAvPath()
 	 * @method string getAvInfectedAction()
-	 * 
+	 *
 	 * @method null setAvMode(string $avMode)
 	 * @method null setAvSocket(string $avsocket)
 	 * @method null setAvHost(string $avHost)
@@ -29,7 +28,6 @@ use \OCP\IConfig;
 	 * @method null setAvMaxFileSize(int $fileSize)
 	 * @method null setAvStreamMaxLength(int $streamMaxLength)
 	 * @method null setAvCmdOptions(string $avCmdOptions)
-	 * @method null setAvChunkSize(int $chunkSize)
 	 * @method null setAvPath(string $avPath)
 	 * @method null setAvInfectedAction(string $avInfectedAction)
 	 */
@@ -46,7 +44,6 @@ class AppConfig {
 		'av_host' => '',
 		'av_port' => '',
 		'av_cmd_options' => '',
-		'av_chunk_size' => '8192',
 		'av_path' => '/usr/bin/clamscan',
 		'av_max_file_size' => -1,
 		'av_stream_max_length' => '26214400',
@@ -60,6 +57,12 @@ class AppConfig {
 	 */
 	public function __construct(IConfig $config) {
 		$this->config = $config;
+	}
+
+	public function getAvChunkSize(){
+		// See http://php.net/manual/en/function.stream-wrapper-register.php#74765
+		// and \OC_Helper::streamCopy
+		return 8192;
 	}
 	
 	/**

--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -16,6 +16,7 @@ use \OCP\IConfig;
 	 * @method string getAvHost()
 	 * @method int getAvPort()
 	 * @method int getAvMaxFileSize()
+	 * @method int getAvStreamMaxLength()
 	 * @method string getAvCmdOptions()
 	 * @method int getAvChunkSize()
 	 * @method string getAvPath()
@@ -26,6 +27,7 @@ use \OCP\IConfig;
 	 * @method null setAvHost(string $avHost)
 	 * @method null setAvPort(int $avPort)
 	 * @method null setAvMaxFileSize(int $fileSize)
+	 * @method null setAvStreamMaxLength(int $streamMaxLength)
 	 * @method null setAvCmdOptions(string $avCmdOptions)
 	 * @method null setAvChunkSize(int $chunkSize)
 	 * @method null setAvPath(string $avPath)
@@ -44,9 +46,10 @@ class AppConfig {
 		'av_host' => '',
 		'av_port' => '',
 		'av_cmd_options' => '',
-		'av_chunk_size' => '1024',
+		'av_chunk_size' => '8192',
 		'av_path' => '/usr/bin/clamscan',
 		'av_max_file_size' => -1,
+		'av_stream_max_length' => '26214400',
 		'av_infected_action' => 'only_log',
 	];
 

--- a/lib/avirwrapper.php
+++ b/lib/avirwrapper.php
@@ -61,7 +61,7 @@ class AvirWrapper extends Wrapper{
 		if (is_resource($stream) && $this->isWritingMode($mode)) {
 			try {
 				$scanner = $this->scannerFactory->getScanner();
-				$scanner->initAsyncScan();
+				$scanner->initScanner();
 				return CallBackWrapper::wrap(
 					$stream,
 					null,

--- a/lib/backgroundscanner.php
+++ b/lib/backgroundscanner.php
@@ -67,50 +67,8 @@ class BackgroundScanner {
 	 */
 	public function run(){
 		// locate files that are not checked yet
-		$dirMimeTypeId = \OC::$server->getMimeTypeLoader()->getId('httpd/unix-directory');
 		try {
-			$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-
-			$sizeLimit = intval($this->appConfig);
-			if ( $sizeLimit === -1 ){
-				$sizeLimitExpr = $qb->expr()->neq('fc.size', $qb->expr()->literal('0'));
-			} else {
-				$sizeLimitExpr = $qb->expr()->andX(
-					$qb->expr()->neq('fc.size', $qb->expr()->literal('0')),
-					$qb->expr()->lt('fc.size', $qb->expr()->literal((string) $sizeLimit))
-				);
-			}
-
-			$qb->select(['fc.fileid'])
-				->from('filecache', 'fc')
-				->leftJoin('fc', 'files_antivirus', 'fa', $qb->expr()->eq('fa.fileid', 'fc.fileid'))
-				->innerJoin(
-					'fc',
-					'storages',
-					'ss',
-					$qb->expr()->andX(
-						$qb->expr()->eq('fc.storage', 'ss.numeric_id'),
-						$qb->expr()->orX(
-							$qb->expr()->like('ss.id', $qb->expr()->literal('local::%')),
-							$qb->expr()->like('ss.id', $qb->expr()->literal('home::%'))
-						)
-					)
-				)
-				->where(
-					$qb->expr()->neq('fc.mimetype', $qb->expr()->literal($dirMimeTypeId))
-				)
-				->andWhere(
-					$qb->expr()->orX(
-						$qb->expr()->isNull('fa.fileid'),
-						$qb->expr()->gt('fc.mtime', 'fa.check_time')
-					)
-				)
-				->andWhere(
-					$qb->expr()->like('fc.path', $qb->expr()->literal('files/%'))
-				)
-				->andWhere( $sizeLimitExpr )
-			;
-			$result = $qb->execute();
+			$result = $this->getFilesForScan();
 		} catch(\Exception $e) {
 			\OC::$server->getLogger()->error( __METHOD__ . ', exception: ' . $e->getMessage(), ['app' => 'files_antivirus']);
 			return;
@@ -125,15 +83,7 @@ class BackgroundScanner {
 				if (!$owner instanceof IUser){
 					continue;
 				}
-				$this->initFilesystemForUser($owner);
-				$view = Filesystem::getView();
-				$path = $view->getPath($fileId);
-				if (!is_null($path)) {
-					$item = new Item($this->l10n, $view, $path, $fileId);
-					$scanner = $this->scannerFactory->getScanner();
-					$status = $scanner->scan($item);
-					$status->dispatch($item, true);
-				}
+				$this->scanOneFile($owner, $fileId);
 				// increased only for successfully scanned files
 				$cnt = $cnt + 1;
 			} catch (\Exception $e){
@@ -141,6 +91,68 @@ class BackgroundScanner {
 			}
 		}
 		$this->tearDownFilesystem();
+	}
+
+	protected function getFilesForScan(){
+		$dirMimeTypeId = \OC::$server->getMimeTypeLoader()->getId('httpd/unix-directory');
+		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+
+		$sizeLimit = intval($this->appConfig->getAvMaxFileSize());
+		if ( $sizeLimit === -1 ){
+			$sizeLimitExpr = $qb->expr()->neq('fc.size', $qb->expr()->literal('0'));
+		} else {
+			$sizeLimitExpr = $qb->expr()->andX(
+				$qb->expr()->neq('fc.size', $qb->expr()->literal('0')),
+				$qb->expr()->lt('fc.size', $qb->expr()->literal((string) $sizeLimit))
+			);
+		}
+
+		$qb->select(['fc.fileid'])
+			->from('filecache', 'fc')
+			->leftJoin('fc', 'files_antivirus', 'fa', $qb->expr()->eq('fa.fileid', 'fc.fileid'))
+			->innerJoin(
+				'fc',
+				'storages',
+				'ss',
+				$qb->expr()->andX(
+					$qb->expr()->eq('fc.storage', 'ss.numeric_id'),
+					$qb->expr()->orX(
+						$qb->expr()->like('ss.id', $qb->expr()->literal('local::%')),
+						$qb->expr()->like('ss.id', $qb->expr()->literal('home::%'))
+					)
+				)
+			)
+			->where(
+				$qb->expr()->neq('fc.mimetype', $qb->expr()->literal($dirMimeTypeId))
+			)
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->isNull('fa.fileid'),
+					$qb->expr()->gt('fc.mtime', 'fa.check_time')
+				)
+			)
+			->andWhere(
+				$qb->expr()->like('fc.path', $qb->expr()->literal('files/%'))
+			)
+			->andWhere( $sizeLimitExpr )
+		;
+		return $qb->execute();
+	}
+
+	/**
+	 * @param IUser $owner
+	 * @param int $fileId
+	 */
+	protected function scanOneFile($owner, $fileId){
+		$this->initFilesystemForUser($owner);
+		$view = Filesystem::getView();
+		$path = $view->getPath($fileId);
+		if (!is_null($path)) {
+			$item = new Item($this->l10n, $view, $path, $fileId);
+			$scanner = $this->scannerFactory->getScanner();
+			$status = $scanner->scan($item);
+			$status->dispatch($item, true);
+		}
 	}
 
 	/**

--- a/lib/db/itemmapper.php
+++ b/lib/db/itemmapper.php
@@ -11,12 +11,8 @@ namespace OCA\Files_Antivirus\Db;
 use OCP\IDb;
 use OCP\AppFramework\Db\Mapper;
 
-use OCA\Files_Antivirus\Db\Item;
-
 class ItemMapper extends Mapper {
 	public function __construct(IDb $db) {
 		parent::__construct($db, 'files_antivirus', '\OCA\Files_Antivirus\Db\Item');
 	}
-	
-	
 }

--- a/lib/item.php
+++ b/lib/item.php
@@ -78,7 +78,7 @@ class Item implements IScannable{
 		
 		$this->isValidSize = $view->filesize($path) > 0;
 		
-		$application = new \OCA\Files_Antivirus\AppInfo\Application();
+		$application = new AppInfo\Application();
 		$config = $application->getContainer()->query('AppConfig');
 		$this->chunkSize = $config->getAvChunkSize();
 	}
@@ -117,7 +117,7 @@ class Item implements IScannable{
 	 * @param boolean $isBackground
 	 */
 	public function processInfected(Status $status, $isBackground) {
-		$application = new \OCA\Files_Antivirus\AppInfo\Application();
+		$application = new AppInfo\Application();
 		$appConfig = $application->getContainer()->query('AppConfig');
 		$infectedAction = $appConfig->getAvInfectedAction();
 		

--- a/lib/item.php
+++ b/lib/item.php
@@ -12,7 +12,7 @@ use OCP\IL10N;
 use OCA\Files_Antivirus\Status;
 use OCA\Files_Antivirus\Activity;
 
-class Item implements iScannable{
+class Item implements IScannable{
 	/**
 	 * Scanned fileid (optional)
 	 * @var int
@@ -182,12 +182,12 @@ class Item implements iScannable{
 			$result = $stmt->execute(array($this->id));
 			if (\OCP\DB::isError($result)) {
 				//TODO: Use logger
-				$this->logError(__METHOD__. ', DB error: ' . \OCP\DB::getErrorMessage($result));
+				$this->logError(__METHOD__. ', DB error: ' . \OCP\DB::getErrorMessage());
 			}
 			$stmt = \OCP\DB::prepare('INSERT INTO `*PREFIX*files_antivirus` (`fileid`, `check_time`) VALUES (?, ?)');
 			$result = $stmt->execute(array($this->id, time()));
 			if (\OCP\DB::isError($result)) {
-				$this->logError(__METHOD__. ', DB error: ' . \OCP\DB::getErrorMessage($result));
+				$this->logError(__METHOD__. ', DB error: ' . \OCP\DB::getErrorMessage());
 			}
 		} catch(\Exception $e) {
 			\OCP\Util::writeLog('files_antivirus', __METHOD__.', exception: '.$e->getMessage(), \OCP\Util::ERROR);

--- a/lib/notification.php
+++ b/lib/notification.php
@@ -13,7 +13,6 @@ class Notification {
 		if (!\OCP\User::isLoggedIn()){
 			return;
 		}
-		$config = \OC::$server->getConfig();
 		$user = \OC::$server->getUserSession()->getUser();
 		$email = $user->getEMailAddress();
 		$displayName = $user->getDisplayName();

--- a/lib/scanner.php
+++ b/lib/scanner.php
@@ -30,22 +30,25 @@ abstract class Scanner {
 	 * @var \OCA\Files_Antivirus\Status
 	 */
 	protected $status;
-	
-	/**
-	 * @var \OCA\Files_Antivirus\AppConfig
-	 */
+
+	/** @var  int */
+	protected $byteCount;
+
+	/** @var  resource */
+	protected $writeHandle;
+
+	/** @var \OCA\Files_Antivirus\AppConfig */
 	protected $appConfig;
-	
+
+	/** @var bool */
+	protected $isLogUsed;
+
 	/**
 	 * Close used resources
 	 */
 	abstract protected function shutdownScanner();
-	
-	/**
-	 * Get a resource to write data into
-	 */
-	abstract protected function getWriteHandle();
-	
+
+
 	public function getStatus(){
 		if ($this->status instanceof Status){
 			return $this->status;
@@ -62,10 +65,7 @@ abstract class Scanner {
 		$this->initScanner();
 
 		while (false !== ($chunk = $item->fread())) {
-			fwrite(
-					$this->getWriteHandle(), 
-					$this->prepareChunk($chunk)
-			);
+			$this->writeChunk($chunk);
 		}
 		
 		$this->shutdownScanner();
@@ -73,21 +73,11 @@ abstract class Scanner {
 	}
 	
 	/**
-	 * Async scan - prepare resources
-	 */
-	public function initAsyncScan(){
-		$this->initScanner();
-	}
-	
-	/**
 	 * Async scan - new portion of data is available
 	 * @param string $data
 	 */
 	public function onAsyncData($data){
-		fwrite(
-				$this->getWriteHandle(),
-				$this->prepareChunk($data)
-		);
+		$this->writeChunk($data);
 	}
 	
 	/**
@@ -102,12 +92,60 @@ abstract class Scanner {
 	/**
 	 * Open write handle. etc
 	 */
-	protected function initScanner(){
+	public function initScanner(){
+		$this->byteCount = 0;
 		$this->status = new Status();
 	}
 
 	/**
+	 * @param string $chunk
+	 */
+	protected function writeChunk($chunk){
+		$this->fwrite(
+			$this->prepareChunk($chunk)
+		);
+	}
+
+	/**
+	 * @param string $data
+	 */
+	protected final function fwrite($data){
+		$dataLength = strlen($data);
+		$fileSizeLimit = intval($this->appConfig->getAvMaxFileSize());
+		if ($fileSizeLimit !== -1 && $this->byteCount + $dataLength > $fileSizeLimit){
+			$this->shutdownScanner();
+			$this->initScanner();
+		}
+
+		$bytesWritten = @fwrite($this->getWriteHandle(), $data);
+		if ($bytesWritten === false || $bytesWritten < $dataLength){
+			if (!$this->isLogUsed) {
+				$this->isLogUsed = true;
+				\OC::$server->getLogger()->warning(
+					'Failed to write a chunk. File is too big?',
+					['app' => 'files_antivirus']
+				);
+			}
+			// retry
+			$this->initScanner();
+			@fwrite($this->getWriteHandle(), $data);
+		} else {
+			$this->byteCount += $bytesWritten;
+		}
+	}
+
+	/**
+	 * Get a resource to write data into
+	 * @return resource
+	 */
+	protected function getWriteHandle(){
+		return $this->writeHandle;
+	}
+
+	/**
 	 * Prepare chunk (if required)
+	 * @param string $data
+	 * @return string
 	 */
 	protected function prepareChunk($data){
 		return $data;

--- a/lib/scanner.php
+++ b/lib/scanner.php
@@ -140,6 +140,7 @@ abstract class Scanner {
 				'reinit scanner',
 				['app' => 'files_antivirus']
 			);
+			$this->shutdownScanner();
 			$isReopenSuccessful = $this->retry();
 		} else {
 			$isReopenSuccessful = true;

--- a/lib/scanner/external.php
+++ b/lib/scanner/external.php
@@ -31,27 +31,27 @@ class External extends \OCA\Files_Antivirus\Scanner {
 		if ($this->useSocket){
 			$avSocket = $this->appConfig->getAvSocket();
 			$this->writeHandle = stream_socket_client('unix://' . $avSocket, $errno, $errstr, 5);
-			if (!$this->writeHandle) {
+			if (!$this->getWriteHandle()) {
 				throw new \RuntimeException('Cannot connect to "' . $avSocket . '": ' . $errstr . ' (code ' . $errno . ')');
 			}
 		} else {
 			$avHost = $this->appConfig->getAvHost();
 			$avPort = $this->appConfig->getAvPort();
 			$this->writeHandle = ($avHost && $avPort) ? @fsockopen($avHost, $avPort) : false;
-			if (!$this->writeHandle) {
+			if (!$this->getWriteHandle()) {
 				throw new \RuntimeException('The clamav module is not configured for daemon mode.');
 			}
 		}
 
 		// request scan from the daemon
-		fwrite($this->writeHandle, "nINSTREAM\n");
+		fwrite($this->getWriteHandle(), "nINSTREAM\n");
 	}
 	
 	protected function shutdownScanner(){
-		fwrite($this->writeHandle, pack('N', 0));
-		$response = fgets($this->writeHandle);
+		fwrite($this->getWriteHandle(), pack('N', 0));
+		$response = fgets($this->getWriteHandle());
 		\OCP\Util::writeLog('files_antivirus', 'Response :: '.$response, \OCP\Util::DEBUG);
-		fclose($this->writeHandle);
+		fclose($this->getWriteHandle());
 		
 		$this->status->parseResponse($response);
 	}

--- a/lib/status.php
+++ b/lib/status.php
@@ -77,7 +77,7 @@ class Status {
 			foreach ($allRules as $rule){
 				if (preg_match($rule->getMatch(), $rawResponse, $matches)){
 					$isMatched = true;
-					$this->numericStatus = $rule->getStatus();
+					$this->numericStatus = intval($rule->getStatus());
 					if (intval($rule->getStatus())===self::SCANRESULT_CLEAN){
 						$this->details = '';
 					} else {
@@ -95,7 +95,7 @@ class Status {
 		} else { // Executable mode
 			$scanStatus = $ruleMapper->findByResult($result);
 			if (is_array($scanStatus) && count($scanStatus)){
-				$this->numericStatus = $scanStatus[0]->getStatus();
+				$this->numericStatus = intval($scanStatus[0]->getStatus());
 				$this->details = $scanStatus[0]->getDescription();
 			}
 			

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -12,7 +12,24 @@ script('files_antivirus', 'settings');
 		    <p class="av_socket"><label for="av_socket"><?php p($l->t('Socket'));?></label><input type="text" id="av_socket" name="avSocket" value="<?php p($_['avSocket']); ?>" title="<?php p($l->t('Clamav Socket.')).' '.$l->t('Not required in Executable Mode.'); ?>"></p>
 			<p class="av_host"><label for="av_host"><?php p($l->t('Host'));?></label><input type="text" id="av_host" name="avHost" value="<?php p($_['avHost']); ?>" title="<?php p($l->t('Address of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
 			<p class="av_port"><label for="av_port"><?php p($l->t('Port'));?></label><input type="text" id="av_port" name="avPort" value="<?php p($_['avPort']); ?>" title="<?php p($l->t('Port number of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
-			<p class="av_chunk_size"><label for="av_chunk_size"><?php p($l->t('Stream Length'));?></label><input type="text" id="av_chunk_size" name="avChunkSize" value="<?php p($_['avChunkSize']); ?>" title="<?php p($l->t('ClamAV StreamMaxLength value in bytes.')). ' ' .$l->t('Not required in Executable Mode.');?>"> bytes</p>
+			<p class="av_chunk_size">
+				<label for="av_chunk_size">
+					<?php p($l->t('Chunk Size'));?>
+				</label>
+				<input type="text" id="av_chunk_size" name="avChunkSize" value="<?php p($_['avChunkSize']); ?>"
+					   title="<?php p($l->t('Chunk size')). ' ' .$l->t('Not required in Executable Mode.');?>"
+				/>
+				<label for="av_chunk_size" class="a-left"><?php p($l->t('bytes'))?></label>
+			</p>
+			<p class="av_stream_max_length">
+				<label for="av_stream_max_length">
+					<?php p($l->t('Stream Length'));?>
+				</label>
+				<input type="text" id="av_stream_max_length" name="avStreamMaxLength" value="<?php p($_['avStreamMaxLength']); ?>"
+					   title="<?php p($l->t('ClamAV StreamMaxLength value in bytes.')). ' ' .$l->t('Not required in Executable Mode.');?>"
+				/>
+				<label for="av_stream_max_length" class="a-left"><?php p($l->t('bytes'))?></label>
+			</p>
 			<p class="av_path">
 				<label for="av_path"><?php p($l->t('Path to clamscan'));?></label><input type="text" id="av_path" name="avPath" value="<?php p($_['avPath']); ?>" title="<?php p($l->t('Path to clamscan executable.')). ' ' .$l->t('Not required in Daemon Mode.');?>" />
 			</p>
@@ -20,9 +37,11 @@ script('files_antivirus', 'settings');
 				<label for="av_cmd_options"><?php p($l->t('Extra command line options (comma-separated)'));?></label><input type="text" id="av_cmd_options" name="avCmdOptions" value="<?php p($_['avCmdOptions']); ?>" />
 			</p>
 			<p class="av_max_file_size">
-				<label for="av_max_file_size"><?php p($l->t('File size limit in bytes, -1 means no limit'));?></label>
-				<input type="text" id="av_max_file_size" name="avMaxFileSize" value="<?php p($_['avMaxFileSize']); ?>" title="<?php p($l->t('File size limit in bytes, -1 means no limit'));?>">
-				bytes
+				<label for="av_max_file_size"><?php p($l->t('File size limit, -1 means no limit'));?></label>
+				<input type="text" id="av_max_file_size" name="avMaxFileSize" value="<?php p($_['avMaxFileSize']); ?>"
+					   title="<?php p($l->t('File size limit in bytes, -1 means no limit'));?>"
+				/>
+				<label for="av_max_file_size" class="a-left"><?php p($l->t('bytes'))?></label>
 			</p>
 			<p class="infected_action"><label for="av_infected_action"><?php p($l->t('Action for infected files found while scanning'));?></label>
 				<select id="av_infected_action" name="avInfectedAction"><?php print_unescaped(html_select_options(array('only_log' => $l->t('Only log'), 'delete' => $l->t('Delete file')), $_['avInfectedAction'])) ?></select>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -12,15 +12,6 @@ script('files_antivirus', 'settings');
 		    <p class="av_socket"><label for="av_socket"><?php p($l->t('Socket'));?></label><input type="text" id="av_socket" name="avSocket" value="<?php p($_['avSocket']); ?>" title="<?php p($l->t('Clamav Socket.')).' '.$l->t('Not required in Executable Mode.'); ?>"></p>
 			<p class="av_host"><label for="av_host"><?php p($l->t('Host'));?></label><input type="text" id="av_host" name="avHost" value="<?php p($_['avHost']); ?>" title="<?php p($l->t('Address of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
 			<p class="av_port"><label for="av_port"><?php p($l->t('Port'));?></label><input type="text" id="av_port" name="avPort" value="<?php p($_['avPort']); ?>" title="<?php p($l->t('Port number of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
-			<p class="av_chunk_size">
-				<label for="av_chunk_size">
-					<?php p($l->t('Chunk Size'));?>
-				</label>
-				<input type="text" id="av_chunk_size" name="avChunkSize" value="<?php p($_['avChunkSize']); ?>"
-					   title="<?php p($l->t('Chunk size')). ' ' .$l->t('Not required in Executable Mode.');?>"
-				/>
-				<label for="av_chunk_size" class="a-left"><?php p($l->t('bytes'))?></label>
-			</p>
 			<p class="av_stream_max_length">
 				<label for="av_stream_max_length">
 					<?php p($l->t('Stream Length'));?>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -6,18 +6,23 @@ script('files_antivirus', 'settings');
 	<form id="antivirus" action="#" method="post">
 		<fieldset class="personalblock">
 			<h2><?php p($l->t('Antivirus Configuration'));?></h2>
-			<p class='av_mode'><label for="av_mode"><?php p($l->t('Mode'));?></label>
+			<p class="av_mode"><label for="av_mode"><?php p($l->t('Mode'));?></label>
 				<select id="av_mode" name="avMode"><?php print_unescaped(html_select_options(array('executable' => $l->t('Executable'), 'daemon' => $l->t('Daemon'), 'socket' => $l->t('Daemon (Socket)')), $_['avMode'])) ?></select>
 			</p>
-		    <p class='av_socket'><label for="av_socket"><?php p($l->t('Socket'));?></label><input type="text" id="av_socket" name="avSocket" value="<?php p($_['avSocket']); ?>" title="<?php p($l->t('Clamav Socket.')).' '.$l->t('Not required in Executable Mode.'); ?>"></p>
-			<p class='av_host'><label for="av_host"><?php p($l->t('Host'));?></label><input type="text" id="av_host" name="avHost" value="<?php p($_['avHost']); ?>" title="<?php p($l->t('Address of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
-			<p class='av_port'><label for="av_port"><?php p($l->t('Port'));?></label><input type="text" id="av_port" name="avPort" value="<?php p($_['avPort']); ?>" title="<?php p($l->t('Port number of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
-			<p class='av_chunk_size'><label for="av_chunk_size"><?php p($l->t('Stream Length'));?></label><input type="text" id="av_chunk_size" name="avChunkSize" value="<?php p($_['avChunkSize']); ?>" title="<?php p($l->t('ClamAV StreamMaxLength value in bytes.')). ' ' .$l->t('Not required in Executable Mode.');?>"> bytes</p>
-			<p class='av_path'>
+		    <p class="av_socket"><label for="av_socket"><?php p($l->t('Socket'));?></label><input type="text" id="av_socket" name="avSocket" value="<?php p($_['avSocket']); ?>" title="<?php p($l->t('Clamav Socket.')).' '.$l->t('Not required in Executable Mode.'); ?>"></p>
+			<p class="av_host"><label for="av_host"><?php p($l->t('Host'));?></label><input type="text" id="av_host" name="avHost" value="<?php p($_['avHost']); ?>" title="<?php p($l->t('Address of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
+			<p class="av_port"><label for="av_port"><?php p($l->t('Port'));?></label><input type="text" id="av_port" name="avPort" value="<?php p($_['avPort']); ?>" title="<?php p($l->t('Port number of Antivirus Host.')). ' ' .$l->t('Not required in Executable Mode.');?>"></p>
+			<p class="av_chunk_size"><label for="av_chunk_size"><?php p($l->t('Stream Length'));?></label><input type="text" id="av_chunk_size" name="avChunkSize" value="<?php p($_['avChunkSize']); ?>" title="<?php p($l->t('ClamAV StreamMaxLength value in bytes.')). ' ' .$l->t('Not required in Executable Mode.');?>"> bytes</p>
+			<p class="av_path">
 				<label for="av_path"><?php p($l->t('Path to clamscan'));?></label><input type="text" id="av_path" name="avPath" value="<?php p($_['avPath']); ?>" title="<?php p($l->t('Path to clamscan executable.')). ' ' .$l->t('Not required in Daemon Mode.');?>" />
 			</p>
 			<p class="av_path">
 				<label for="av_cmd_options"><?php p($l->t('Extra command line options (comma-separated)'));?></label><input type="text" id="av_cmd_options" name="avCmdOptions" value="<?php p($_['avCmdOptions']); ?>" />
+			</p>
+			<p class="av_max_file_size">
+				<label for="av_max_file_size"><?php p($l->t('File size limit in bytes, -1 means no limit'));?></label>
+				<input type="text" id="av_max_file_size" name="avMaxFileSize" value="<?php p($_['avMaxFileSize']); ?>" title="<?php p($l->t('File size limit in bytes, -1 means no limit'));?>">
+				bytes
 			</p>
 			<p class="infected_action"><label for="av_infected_action"><?php p($l->t('Action for infected files found while scanning'));?></label>
 				<select id="av_infected_action" name="avInfectedAction"><?php print_unescaped(html_select_options(array('only_log' => $l->t('Only log'), 'delete' => $l->t('Delete file')), $_['avInfectedAction'])) ?></select>

--- a/tests/ActivityTest.php
+++ b/tests/ActivityTest.php
@@ -7,11 +7,11 @@
  */
 
 namespace OCA\Files_antivirus\Tests;
-//namespace OCA\Files_Antivirus\Cron;
 
 use OCA\Files_Antivirus\Activity;
 
 class ActivityTest extends TestBase {
+	/** @var  Activity */
 	protected $activity;
 	
 	public function setUp(){

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Copyright (c) 2016 Victor Dubiniuk <victor.dubiniuk@gmail.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+
+namespace OCA\Files_antivirus\Tests;
+
+use OC\Files\Filesystem;
+use OC\Files\Storage\Storage;
+use OC\Files\Storage\Temporary;
+use OC\Files\View;
+use OCA\Files_Antivirus\AppConfig;
+use OCA\Files_Antivirus\AvirWrapper;
+use OCA\Files_Antivirus\ScannerFactory;
+use Test\Util\User\Dummy;
+
+// mmm. IDK why autoloader fails on this class
+include_once dirname(dirname(dirname(__DIR__))) . '/tests/lib/Util/User/Dummy.php';
+
+class AvirWrapperTest extends TestBase {
+	/**
+	 * @var Temporary
+	 */
+	private $storage;
+
+	protected $scannerFactory;
+
+	protected $isWrapperRegistered = false;
+
+	public function setUp() {
+		parent::setUp();
+		$logger = $this->container->query('Logger');
+		$this->scannerFactory = new ScannerFactory(
+			$this->streamConfig,
+ 			$logger
+		);
+
+		\OC_User::clearBackends();
+		\OC_User::useBackend(new Dummy());
+		Filesystem::clearMounts();
+
+		//login
+		\OC::$server->getUserManager()->createUser('testo', 'test');
+		\OC::$server->getUserSession()->login('testo', 'test');
+		\OC::$server->getSession()->set('user_id', 'testo');
+		\OC::$server->getUserFolder('testo');
+		\OC_Util::setupFS('testo');
+
+		$this->storage = new Temporary(array());
+		if (!$this->isWrapperRegistered) {
+			Filesystem::addStorageWrapper(
+				'oc_avir_test',
+				function ($mountPoint, $storage) use ($logger) {
+					/**
+					 * @var Storage $storage
+					 */
+					if ($storage instanceof Storage) {
+						return new AvirWrapper([
+							'storage' => $storage,
+							'scannerFactory' => $this->scannerFactory,
+							'l10n' => $this->l10n,
+							'logger' => $logger
+						]);
+					} else {
+						return $storage;
+					}
+				},
+				1
+			);
+			$this->isWrapperRegistered = true;
+		}
+		Filesystem::init('testo', '');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\InvalidContentException
+	 */
+	/*public function testInfected(){
+		$fd = Filesystem::fopen('killing bee', 'w+');
+		@fwrite($fd, 'it ' . DummyClam::TEST_SIGNATURE);
+		@fclose($fd);
+		Filesystem::unlink('killing kee');
+	}*/
+
+	/**
+	 * @expectedException \OCP\Files\InvalidContentException
+	 */
+	public function testBigInfected(){
+		$fd = Filesystem::fopen('killing whale', 'w+');
+		@fwrite($fd, str_repeat('0', DummyClam::TEST_STREAM_SIZE-2));
+		@fwrite($fd, DummyClam::TEST_SIGNATURE);
+		@fclose($fd);
+		Filesystem::unlink('killing whale');
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		Filesystem::tearDown();
+		\OC_Util::tearDownFS();
+		\OC::$server->getUserManager()->get('testo')->delete();
+	}
+}

--- a/tests/DummyClam.php
+++ b/tests/DummyClam.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright (c) 2016 Victor Dubiniuk <victor.dubiniuk@gmail.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\Files_antivirus\Tests;
+
+class DummyClam {
+	const TEST_STREAM_SIZE = 524288; // 512K
+	const TEST_SIGNATURE = 'does the job';
+	private $chunkSize = 8192; // 8K
+	private $socketDN;
+	private $socket;
+
+	public function __construct($socketPath){
+		$this->socketDN = $socketPath;
+	}
+
+	public function startServer(){
+		$this->socket = stream_socket_server($this->socketDN, $errNo, $errStr);
+		if (!is_resource($this->socket)){
+			throw new \Exception(
+				sprintf(
+					'Unable to open socket. Error code: %s. Error message: "%s"',
+					$errNo,
+					$errStr
+				)
+			);
+		}
+		// listen
+		while (true){
+			$connection = @stream_socket_accept($this->socket);
+			if (is_resource($connection)){
+				stream_set_blocking($connection, false);
+				$this->handleConnection($connection);
+				@fclose($connection);
+			}
+		}
+	}
+	protected function handleConnection($connection){
+		$buffer = '';
+		$isAborted = false;
+		do {
+			$chunk = fread($connection, $this->chunkSize);
+			$nextBufferSize = strlen($buffer) + strlen($chunk);
+			if ($nextBufferSize > self::TEST_STREAM_SIZE){
+				$isAborted = true;
+				break;
+			}
+			$buffer = $buffer . $chunk;
+		} while (!$this->shouldCloseConnection($buffer));
+		if (!$isAborted){
+			//echo $buffer;
+			$response = strpos($buffer, self::TEST_SIGNATURE) !== false
+				? 'Ohoho: Criminal.Joboholic FOUND'
+				: 'Scanned OK'
+			;
+			fwrite($connection, $response);
+		}
+	}
+	protected function shouldCloseConnection($buffer){
+		$needle = pack('N', 0);
+		return substr($buffer,-strlen($needle)) == $needle;
+	}
+}

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -51,4 +51,9 @@ class ItemTest extends TestBase {
 		$chunk = $item->fread();
 		$this->assertEquals(self::CONTENT, $chunk);
 	}
+
+	public function tearDown() {
+		parent::tearDown();
+		\OC_Util::tearDownFS();
+	}
 }

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -41,12 +41,6 @@ class ItemTest extends TestBase {
 		\OC\Files\Filesystem::init('test', '');
 		$view = new \OC\Files\View('/test/files');
 		$view->file_put_contents('file1', self::CONTENT);
-		$this->config->method('__call')
-			->with(
-				$this->equalTo('getAvChunkSize')
-			)
-			->willReturn('1024')
-		;
 	}
 	
 	public function testRead() {

--- a/tests/Mock/Config.php
+++ b/tests/Mock/Config.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright (c) 2016 Victor Dubiniuk <victor.dubiniuk@gmail.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+
+namespace OCA\Files_antivirus\Tests\Mock;
+
+use \OCA\Files_antivirus\AppConfig;
+use \OCA\Files_antivirus\Tests\DummyClam;
+
+class Config extends AppConfig {
+	public function getAppValue($key) {
+		$map = [
+			'av_host' => '127.0.0.1',
+			'av_port' => 5555,
+			'av_stream_max_length' => DummyClam::TEST_STREAM_SIZE,
+			'av_mode' => 'daemon'
+		];
+		if (array_key_exists($key, $map)){
+			return $map[$key];
+		}
+		return '';
+	}
+}

--- a/tests/Mock/ScannerFactory.php
+++ b/tests/Mock/ScannerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Copyright (c) 2016 Victor Dubiniuk <victor.dubiniuk@gmail.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+
+namespace OCA\Files_antivirus\Tests\Mock;
+
+use OCA\Files_Antivirus\Scanner\External;
+
+class ScannerFactory extends \OCA\Files_antivirus\ScannerFactory{
+	public function getScanner() {
+		return new External($this->appConfig);
+	}
+}

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -36,7 +36,7 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 		$this->config->method('__call')
 			->will($this->returnCallback(array($this, 'getAppValue')));
 		
-		$this->l10n = $this->getMockBuilder('\OC_L10N')
+		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
 				->disableOriginalConstructor()
 				->getMock()
 		;

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -47,8 +47,6 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 		switch ($methodName){
 			case 'getAvPath':
 				return  __DIR__ . '/avir.sh';
-			case 'getAvChunkSize':
-				return 1024;
 			case 'getAvMode':
 				return 'executable';
 		}

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -17,7 +17,6 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 	protected $application;
 	protected $container;
 	protected $config;
-	protected $streamConfig;
 	protected $l10n;
 	
 
@@ -37,12 +36,6 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 		$this->config->method('__call')
 			->will($this->returnCallback(array($this, 'getAppValue')));
 
-		$this->streamConfig = $this->getMockBuilder('\OCA\Files_Antivirus\AppConfig')
-			->disableOriginalConstructor()
-			->getMock()
-		;
-		$this->streamConfig->method('__call')
-			->will($this->returnCallback(array($this, 'getAppStreamValue')));
 
 		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
 				->disableOriginalConstructor()
@@ -57,18 +50,6 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 				return  __DIR__ . '/avir.sh';
 			case 'getAvMode':
 				return 'executable';
-		}
-	}
-	public function getAppStreamValue($methodName){
-		switch ($methodName){
-			case 'getAvHost':
-				return '127.0.0.1';
-			case 'getAvPort':
-				return 5555;
-			case 'getAvStreamMaxLength':
-				return DummyClam::TEST_STREAM_SIZE;
-			case 'getAvMode':
-				return 'daemon';
 		}
 	}
 }

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -17,6 +17,7 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 	protected $application;
 	protected $container;
 	protected $config;
+	protected $streamConfig;
 	protected $l10n;
 	
 
@@ -35,20 +36,39 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 		;
 		$this->config->method('__call')
 			->will($this->returnCallback(array($this, 'getAppValue')));
-		
+
+		$this->streamConfig = $this->getMockBuilder('\OCA\Files_Antivirus\AppConfig')
+			->disableOriginalConstructor()
+			->getMock()
+		;
+		$this->streamConfig->method('__call')
+			->will($this->returnCallback(array($this, 'getAppStreamValue')));
+
 		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
 				->disableOriginalConstructor()
 				->getMock()
 		;
 		$this->l10n->method('t')->will($this->returnArgument(0));
 	}
-	
+
 	public function getAppValue($methodName){
 		switch ($methodName){
 			case 'getAvPath':
 				return  __DIR__ . '/avir.sh';
 			case 'getAvMode':
 				return 'executable';
+		}
+	}
+	public function getAppStreamValue($methodName){
+		switch ($methodName){
+			case 'getAvHost':
+				return '127.0.0.1';
+			case 'getAvPort':
+				return 5555;
+			case 'getAvStreamMaxLength':
+				return DummyClam::TEST_STREAM_SIZE;
+			case 'getAvMode':
+				return 'daemon';
 		}
 	}
 }

--- a/tests/avirserver.php
+++ b/tests/avirserver.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OCA\Files_antivirus\Tests;
+
+include __DIR__ . '/DummyClam.php';
+
+set_time_limit(0);
+$socketPath = 'tcp://0.0.0.0:5555';
+$clam = new DummyClam($socketPath);
+$clam->startServer();

--- a/tests/cron/TaskTest.php
+++ b/tests/cron/TaskTest.php
@@ -37,6 +37,7 @@ class TaskTest extends TestBase {
 		$backgroundScanner = new BackgroundScanner(
 				$this->scannerFactory,
 				$this->l10n,
+				$this->container->query('AppConfig'),
 				$this->container->getServer()->getRootFolder(),
 				$this->container->getServer()->getUserSession()
 		);


### PR DESCRIPTION
### Description
- Adds File size limit
- Fixes https://github.com/owncloud/files_antivirus/issues/124 and https://github.com/owncloud/files_antivirus/issues/125

### Changes in Docs:
__Stream Length__ (bytes)  `26214400` (25Mb) by default.  __Should be <=__  than  `StreamMaxLength` ClamAV value
 __File size limit, -1 means no limit__ (bytes)  `-1` by default - prevent background scanner from checking large files (Has no effect while scanning newly uploaded files)

### To test: 
1. set StreamMaxLength in `/etc/clamd.conf` to e.g. 10M 
2. Configure the app in daemon or daemon(socket) mode
3. cat several 100Mb files with EICAR signature
4. Try upload or background scan
