### PR TITLE
[Stable8.2] minor fixes

### DIFF
--- a/appinfo/preupdate.php
+++ b/appinfo/preupdate.php
@@ -1,6 +1,6 @@
 <?php
 
-$installedVersion=OCP\Config::getAppValue('files_antivirus', 'installed_version');
+$installedVersion = \OC::$server->getConfig()->getAppValue('files_antivirus', 'installed_version');
 if (version_compare($installedVersion, '0.6', '<')) {
 	$query = OCP\DB::prepare( 'SELECT COUNT(*) AS `count`, `fileid` FROM `*PREFIX*files_antivirus` GROUP BY `fileid` HAVING COUNT(*) > 1' );
 	$result = $query->execute();

--- a/appinfo/update.php
+++ b/appinfo/update.php
@@ -7,7 +7,7 @@
  */
 
 
-$installedVersion = \OCP\Config::getAppValue('files_antivirus', 'installed_version');
+$installedVersion = \OC::$server->getConfig()->getAppValue('files_antivirus', 'installed_version');
 
 if (version_compare($installedVersion, '0.5', '<')) {
 	$app = new \OCA\Files_Antivirus\AppInfo\Application();
@@ -21,7 +21,8 @@ if (version_compare($installedVersion, '0.6', '<')) {
 	$jobs = $jobList->getAll();
 	foreach ($jobs as $job) {
 		$jobArg = $job->getArgument();
-		if($jobArg[0]=='OC_Files_Antivirus_BackgroundScanner')
+		if($jobArg[0] === 'OC_Files_Antivirus_BackgroundScanner') {
 			$jobList->remove($job);
+		}
 	}
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -45,7 +45,7 @@ var antivirusSettings = antivirusSettings || {
 		row = $(node).parent(),
 		data = {
 			id : row.data('id'),
-			status_type : row.find('.status-type select').val(),
+			statusType : row.find('.status-type select').val(),
 			match : row.children('.match').text(),
 			description : row.children('.description').text(),
 			status : row.find('.scan-result select').val()

--- a/lib/avirwrapper.php
+++ b/lib/avirwrapper.php
@@ -70,7 +70,7 @@ class AvirWrapper extends Wrapper{
 					}, 
 					function () use ($scanner, $path) {
 						$status = $scanner->completeAsyncScan();
-						if ($status->getNumericStatus() == \OCA\Files_Antivirus\Status::SCANRESULT_INFECTED){
+						if (intval($status->getNumericStatus()) === \OCA\Files_Antivirus\Status::SCANRESULT_INFECTED){
 							//prevent from going to trashbin
 							if (App::isEnabled('files_trashbin')) {
 								\OCA\Files_Trashbin\Storage::preRenameHook([]);

--- a/lib/backgroundscanner.php
+++ b/lib/backgroundscanner.php
@@ -51,50 +51,76 @@ class BackgroundScanner {
 			return;
 		}
 		// locate files that are not checked yet
-		$dirMimetypeId = \OC::$server->getMimeTypeLoader()->getId('httpd/unix-directory');
-		$sql = 'SELECT `*PREFIX*filecache`.`fileid`, `*PREFIX*storages`.*'
-			.' FROM `*PREFIX*filecache`'
-			.' LEFT JOIN `*PREFIX*files_antivirus` ON `*PREFIX*files_antivirus`.`fileid` = `*PREFIX*filecache`.`fileid`'
-			.' JOIN `*PREFIX*storages` ON `*PREFIX*storages`.`numeric_id` = `*PREFIX*filecache`.`storage`'
-			.' WHERE `mimetype` != ?'
-			.' AND (`*PREFIX*storages`.`id` LIKE ? OR `*PREFIX*storages`.`id` LIKE ?)'
-			.' AND (`*PREFIX*files_antivirus`.`fileid` IS NULL OR `mtime` > `check_time`)'
-			.' AND `path` LIKE ?'
-			.' AND `*PREFIX*filecache`.`size` != 0';
-		$stmt = \OCP\DB::prepare($sql, 5);
+		$dirMimeTypeId = \OC::$server->getMimeTypeLoader()->getId('httpd/unix-directory');
 		try {
-			$result = $stmt->execute(array($dirMimetypeId, 'local::%', 'home::%', 'files/%'));
-			if (\OCP\DB::isError($result)) {
-				\OCP\Util::writeLog('files_antivirus', __METHOD__. 'DB error: ' . \OCP\DB::getErrorMessage($result), \OCP\Util::ERROR);
-				return;
-			}
+			$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$qb->select(['fc.fileid'])
+				->from('filecache', 'fc')
+				->leftJoin('fc', 'files_antivirus', 'fa', $qb->expr()->eq('fa.fileid', 'fc.fileid'))
+				->innerJoin(
+					'fc',
+					'storages',
+					'ss',
+					$qb->expr()->andX(
+						$qb->expr()->eq('fc.storage', 'ss.numeric_id'),
+						$qb->expr()->orX(
+							$qb->expr()->like('ss.id', $qb->expr()->literal('local::%')),
+							$qb->expr()->like('ss.id', $qb->expr()->literal('home::%'))
+						)
+					)
+				)
+				->where(
+					$qb->expr()->neq('fc.mimetype', $qb->expr()->literal($dirMimeTypeId))
+				)
+				->andWhere(
+					$qb->expr()->orX(
+						$qb->expr()->isNull('fa.fileid'),
+						$qb->expr()->gt('fc.mtime', 'fa.check_time')
+					)
+				)
+				->andWhere(
+					$qb->expr()->like('fc.path', $qb->expr()->literal('files/%'))
+				)
+				->andWhere(
+					$qb->expr()->neq('fc.size', $qb->expr()->literal('0'))
+				)
+				->setMaxResults(5)
+			;
+			$result = $qb->execute();
 		} catch(\Exception $e) {
-			\OCP\Util::writeLog('files_antivirus', __METHOD__.', exception: '.$e->getMessage(), \OCP\Util::ERROR);
+			\OC::$server->getLogger()->error( __METHOD__ . ', exception: ' . $e->getMessage(), ['app' => 'files_antivirus']);
 			return;
 		}
-	
-		$view = new \OC\Files\View('/');
-		while ($row = $result->fetchRow()) {
-			$path = $view->getPath($row['fileid']);
-			if (!is_null($path)) {
-				$item = new Item($this->l10n, $view, $path, $row['fileid']);
-				$scanner = $this->scannerFactory->getScanner();
-				$status = $scanner->scan($item);					
-				$status->dispatch($item, true);
+
+
+		$view = new \OC\Files\View('');
+		try {
+			while ($row = $result->fetch()) {
+				$path = $view->getPath($row['fileid']);
+				if (!is_null($path)) {
+					$item = new Item($this->l10n, $view, $path, $row['fileid']);
+					$scanner = $this->scannerFactory->getScanner();
+					$status = $scanner->scan($item);
+					$status->dispatch($item, true);
+				}
 			}
+		} catch (\Exception $e){
+			\OC::$server->getLogger()->error( __METHOD__ . ', exception: ' . $e->getMessage(), ['app' => 'files_antivirus']);
 		}
 		\OC_Util::tearDownFS();
 	}
-	
+
 	/**
 	 * A hack to access files and views. Better than before.
+	 *
+	 * @return bool
 	 */
 	protected function initFS(){
 		//Need any valid user to mount FS
 		$results = $this->userManager->search('', 2, 0);
 		$anyUser = array_pop($results);
 		if (is_null($anyUser)) {
-			\OCP\Util::writeLog('files_antivirus', "Failed to setup file system", \OCP\Util::ERROR);
+			\OC::$server->getLogger()->error("Failed to setup file system", ['app' => 'files_antivirus']);
 			return false;
 		}
 		\OC_Util::tearDownFS();
@@ -102,7 +128,6 @@ class BackgroundScanner {
 		return true;
 	}
 
-	
 	/**
 	 * @deprecated 
 	 */

--- a/lib/db/rule.php
+++ b/lib/db/rule.php
@@ -69,13 +69,14 @@ class Rule extends Entity implements JsonSerializable{
 	 * @return array
 	 */
 	public function jsonSerialize() {
-		return array(
+		return [
+			'id' => $this->id,
 			'group_id' => $this->groupId,
 			'status_type' => $this->statusType,
 			'result' => $this->result,
 			'match' => $this->match,
 			'description' => $this->description,
 			'status' => $this->status
-		);
+		];
 	}
 }

--- a/lib/notification.php
+++ b/lib/notification.php
@@ -13,34 +13,33 @@ class Notification {
 		if (!\OCP\User::isLoggedIn()){
 			return;
 		}
-		$email = \OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', '');
-		if (\OCP\App::isEnabled(user_ldap)){
-                        $user  = \OCP\Config::getUserValue(\OCP\User::getUser(), 'user_ldap', 'displayName', '');
-                        if (empty($user)) {
-                                $user = \OCP\User::getUser();
-                        }
-                }
-                else {
-                        $user = \OCP\User::getUser();
-                };
+		$config = \OC::$server->getConfig();
+		$user = \OC::$server->getUserSession()->getUser();
+		$email = $user->getEMailAddress();
+		$displayName = $user->getDisplayName();
+		if ( strval($displayName) ==='' ) {
+			$displayName = $user->getUID();
+		}
 		\OCP\Util::writeLog('files_antivirus', 'Email: '.$email, \OCP\Util::DEBUG);
 		if (!empty($email)) {
-			$defaults = new \OCP\Defaults();
-			$tmpl = new \OCP\Template('files_antivirus', 'notification');
-			$tmpl->assign('file', $path);
-			$tmpl->assign('host', \OCP\Util::getServerHost());
-			$tmpl->assign('user', \OCP\User::getDisplayName());
-			$msg = $tmpl->fetchPage();
-			$from = \OCP\Util::getDefaultEmailAddress('security-noreply');
-			\OCP\Util::sendMail(
-					$email,
-					$user,
-					\OCP\Util::getL10N('files_antivirus')->t('Malware detected'),
-					$msg,
-					$from,
-					$defaults->getName(),
-					true
-			);
+			try {
+				$tmpl = new \OCP\Template('files_antivirus', 'notification');
+				$tmpl->assign('file', $path);
+				$tmpl->assign('host', \OC::$server->getRequest()->getServerHost());
+				$tmpl->assign('user', $displayName);
+				$msg = $tmpl->fetchPage();
+				$from = \OCP\Util::getDefaultEmailAddress('security-noreply');
+				$mailer = \OC::$server->getMailer();
+				$message = $mailer->createMessage();
+				$message->setSubject(\OCP\Util::getL10N('files_antivirus')->t('Malware detected'));
+				$message->setFrom([$from => 'ownCloud Notifier']);
+				$message->setTo([$email => $displayName]);
+				$message->setPlainBody($msg);
+				$message->setHtmlBody($msg);
+				$mailer->send($message);
+			} catch (\Exception $e){
+				\OC::$server->getLogger()->error( __METHOD__ . ', exception: ' . $e->getMessage(), ['app' => 'files_antivirus']);
+			}
 		}
 	}
 }

--- a/lib/status.php
+++ b/lib/status.php
@@ -78,7 +78,7 @@ class Status {
 				if (preg_match($rule->getMatch(), $rawResponse, $matches)){
 					$isMatched = true;
 					$this->numericStatus = $rule->getStatus();
-					if ($rule->getStatus()==self::SCANRESULT_CLEAN){
+					if (intval($rule->getStatus())===self::SCANRESULT_CLEAN){
 						$this->details = '';
 					} else {
 						$this->details = isset($matches[1]) ? $matches[1] : 'unknown';

--- a/tests/db/ruletest.php
+++ b/tests/db/ruletest.php
@@ -28,11 +28,14 @@ class Test_Files_Antivirus_Db_RuleTest extends \OCA\Files_Antivirus\Tests\Testba
 			'description' => "",
 			'status' => \OCA\Files_Antivirus\Status::SCANRESULT_CLEAN
 		];
-		
+
 		$rule = Rule::fromParams($data);
+		$actual = $rule->jsonSerialize();
+		$this->assertArrayHasKey('id', $actual);
+		unset($actual['id']);
 		$this->assertEquals(
-				$expected,
-				$rule->jsonSerialize()
+			$expected,
+			$actual
 		);
 	}
 }


### PR DESCRIPTION
A small part of fixes from master. 
Unfortunately new way of resolving owner and path by fileId is not backportable.

Taken from https://github.com/owncloud/files_antivirus/pull/128

 - uses a batch of 10 successfully scanned files
 - Fixes duplication of rules on save in `Advanced` config section,
 - removes deprecated methods invocation
 - improves OC codechecker results.