### PR TITLE
add isScannableSize()

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -95,11 +95,13 @@ class Application extends App {
 				 * @var \OC\Files\Storage\Storage $storage
 				 */
 				if ($storage instanceof \OC\Files\Storage\Storage) {
+					$appConfig = $this->getContainer()->query('AppConfig');
 					$scannerFactory = $this->getContainer()->query('ScannerFactory');
 					$l10n = $this->getContainer()->query('L10N');
 					$logger = $this->getContainer()->query('Logger');
 					return new AvirWrapper([
 						'storage' => $storage,
+						'appConfig' => $appConfig,
 						'scannerFactory' => $scannerFactory,
 						'l10n' => $l10n,
 						'logger' => $logger

--- a/lib/avirwrapper.php
+++ b/lib/avirwrapper.php
@@ -153,10 +153,10 @@ class AvirWrapper extends Wrapper{
 	private function isScannableSize($filename) {
 		$scanSizeLimit = intval($this->appConfig->getAvMaxFileSize());
 		$size = false;
-
+		
 		// PUT via webdav
-		if ($_SERVER['REQUEST_METHOD'] === 'PUT' && isset($_SERVER['CONTENT_LENGTH'])) {
-			$size = $_SERVER['CONTENT_LENGTH'];
+		if (isset($_SERVER['REQUEST_METHOD']) && isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['REQUEST_METHOD'] === 'PUT'){
+			$size = intval($_SERVER['CONTENT_LENGTH']);
 		}
 
 		return $scanSizeLimit === -1 || $size === false || $scanSizeLimit >= $size;

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -30,7 +30,7 @@ script('files_antivirus', 'settings');
 			<p class="av_max_file_size">
 				<label for="av_max_file_size"><?php p($l->t('File size limit, -1 means no limit'));?></label>
 				<input type="text" id="av_max_file_size" name="avMaxFileSize" value="<?php p($_['avMaxFileSize']); ?>"
-					   title="<?php p($l->t('Background scan file size limit in bytes, -1 means no limit'));?>"
+					   title="<?php p($l->t('File size limit in bytes, -1 means no limit'));?>"
 				/>
 				<label for="av_max_file_size" class="a-left"><?php p($l->t('bytes'))?></label>
 			</p>

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -83,6 +83,7 @@ class AvirWrapperTest extends TestBase {
 		if ($storage instanceof Storage) {
 			return new AvirWrapper([
 				'storage' => $storage,
+				'appConfig' => $this->config,
 				'scannerFactory' => $this->scannerFactory,
 				'l10n' => $this->l10n,
 				'logger' => $this->container->query('Logger')


### PR DESCRIPTION
This PR prevents scanning files bigger than `appConfig->getAvMaxFileSize`. By default it is -1 (no limit).

The title on the settings page seems to never have been visible. I assume because some tipsy or whatever js replaces the input title with the label title. I aligned it with the label, now.

This changes the behavior, because now if you set a File size limit files bigger than it will not even be sent to the scanner. Arguably, that may very well be what you want when reading the label.

Also may need an udpate of the documentation. cc @settermjd 

- [ ] Tests