### PR TITLE
Fix Call to a member function getUser() on a non-object at stable9.1

### DIFF
--- a/lib/backgroundscanner.php
+++ b/lib/backgroundscanner.php
@@ -164,7 +164,8 @@ class BackgroundScanner {
 		$mountCache = $mountProviderCollection->getMountCache();
 		$mounts = $mountCache->getMountsForFileId($fileId);
 		if (!empty($mounts)) {
-			$user = $mounts[0]->getUser();
+			$mount = reset($mounts);
+			$user = $mount->getUser();
 			if ($user instanceof IUser) {
 				return $user;
 			}


### PR DESCRIPTION
Fixes https://github.com/owncloud/enterprise/issues/1963

```
{"reqId":"xNiXSFMPti1l5Y9eD0ef","remoteAddr":"","app":"PHP","message":"Undefined offset: 0 at \/srv\/www\/htdocs\/owncloud\/apps\/files_antivirus\/lib\/backgroundscanner.php#167","level":3,"time":"2017-04-25T07:43:08+02:00","method":"--","url":"--","user":"--"}
{"reqId":"xNiXSFMPti1l5Y9eD0ef","remoteAddr":"","app":"PHP","message":"Call to a member function getUser() on a non-object at \/srv\/www\/htdocs\/owncloud\/apps\/files_antivirus\/lib\/backgroundscanner.php#167","level":3,"time":"2017-04-25T07:43:08+02:00","method":"--","url":"--","user":"--"}
```

Not sure how to reproduce so untested :/

Master is not affected, because it uses another way of user detection.