### PR TITLE
Get uploaded file size correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ nbproject
 # Mac OS
 .DS_Store
 
-tests/clover.xml
+tests/unit/clover.xml

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -15,6 +15,7 @@ use OCA\Files_Antivirus\Controller\RuleController;
 use OCA\Files_Antivirus\Controller\SettingsController;
 use OCA\Files_Antivirus\Db\RuleMapper;
 use OCA\Files_Antivirus\BackgroundScanner;
+use OCA\Files_Antivirus\RequestHelper;
 use OCA\Files_Antivirus\ScannerFactory;
 
 use \OCA\Files_Antivirus\AvirWrapper;
@@ -67,7 +68,13 @@ class Application extends App {
 			return new RuleMapper(
 				$c->query('ServerContainer')->getDb()
 			);
-        });
+		});
+
+		$container->registerService('RequestHelper', function($c) {
+			return new RequestHelper(
+				$c->query('ServerContainer')->getRequest()
+			);
+		});
 		
 		/**
 		 * Core
@@ -98,12 +105,14 @@ class Application extends App {
 					$scannerFactory = $this->getContainer()->query('ScannerFactory');
 					$l10n = $this->getContainer()->query('L10N');
 					$logger = $this->getContainer()->query('Logger');
+					$requestHelper = $this->getContainer()->query('RequestHelper');
 					return new AvirWrapper([
 						'storage' => $storage,
 						'appConfig' => $appConfig,
 						'scannerFactory' => $scannerFactory,
 						'l10n' => $l10n,
-						'logger' => $logger
+						'logger' => $logger,
+						'requestHelper' => $requestHelper
 					]);
 				} else {
 					return $storage;

--- a/lib/RequestHelper.php
+++ b/lib/RequestHelper.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright (c) 2017 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\Files_Antivirus;
+
+use \OCP\IRequest;
+
+class RequestHelper {
+
+	/** @var  IRequest */
+	private $request;
+
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	/**
+	 * Get current upload size
+	 * returns null for chunks and when there is no upload
+	 *
+	 * @param string $path
+	 * @return int|null
+	 */
+	public function getUploadSize($path) {
+		$uploadSize = null;
+
+		$requestMethod = $this->request->getMethod();
+		$isRemoteScript = $this->isScriptName('remote.php');
+		// Are we uploading anything?
+		if (in_array($requestMethod, ['MOVE', 'PUT']) && $isRemoteScript) {
+			// v1 && v2 Chunks are not scanned
+			if (
+				\OC_FileChunking::isWebdavChunk()
+				|| ($requestMethod === 'PUT' &&  strpos($path, 'uploads/') === 0)
+			) {
+				return null;
+			}
+
+			if ($requestMethod === 'PUT') {
+				$uploadSize = (int)$this->request->getHeader('CONTENT_LENGTH');
+			} else {
+				$uploadSize = (int)$this->request->getHeader('OC_TOTAL_LENGTH');
+			}
+		}
+
+		return $uploadSize;
+	}
+
+	/**
+	 *
+	 * @param string $string
+	 * @return bool
+	 */
+	public function isScriptName($string) {
+		$pattern = sprintf('|/%s|', preg_quote($string));
+		return preg_match($pattern, $this->request->getScriptName()) === 1;
+	}
+}

--- a/tests/unit/AvirWrapperTest.php
+++ b/tests/unit/AvirWrapperTest.php
@@ -84,7 +84,8 @@ class AvirWrapperTest extends TestBase {
 				'appConfig' => $this->config,
 				'scannerFactory' => $this->scannerFactory,
 				'l10n' => $this->l10n,
-				'logger' => $this->container->query('Logger')
+				'logger' => $this->container->query('Logger'),
+				'requestHelper' => $this->container->query('RequestHelper'),
 			]);
 		} else {
 			return $storage;

--- a/tests/unit/ChunkUploadTest.php
+++ b/tests/unit/ChunkUploadTest.php
@@ -82,7 +82,8 @@ class ChunkUploadTest extends TestBase{
 				'appConfig' => $this->config,
 				'scannerFactory' => $this->scannerFactory,
 				'l10n' => $this->l10n,
-				'logger' => $this->container->query('Logger')
+				'logger' => $this->container->query('Logger'),
+				'requestHelper' => $this->container->query('RequestHelper'),
 			]);
 		} else {
 			return $storage;

--- a/tests/unit/Mock/Config.php
+++ b/tests/unit/Mock/Config.php
@@ -19,7 +19,8 @@ class Config extends AppConfig {
 			'av_host' => '127.0.0.1',
 			'av_port' => 5555,
 			'av_stream_max_length' => DummyClam::TEST_STREAM_SIZE,
-			'av_mode' => 'daemon'
+			'av_mode' => 'daemon',
+			'av_max_file_size' => '-1'
 		];
 		if (array_key_exists($key, $map)){
 			return $map[$key];

--- a/tests/unit/TestBase.php
+++ b/tests/unit/TestBase.php
@@ -50,6 +50,8 @@ abstract class TestBase extends \PHPUnit_Framework_TestCase {
 				return  __DIR__ . '/../util/avir.sh';
 			case 'getAvMode':
 				return 'executable';
+			case 'getAvMaxFileSize':
+				return -1;
 		}
 	}
 }


### PR DESCRIPTION
- Properly detect size for chunking/normal upload
- Don't scan chunks for DAV v1/v2
- Ignore calls to `fopen` in case there is no upload (scan file from the storage wrapper only if it is related to the upload)
- Add a debug message to track the decision 

Fixes 
https://github.com/owncloud/files_antivirus/issues/179
https://github.com/owncloud/enterprise/issues/2227
