### PR TITLE
skip running background scan when disabled

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -20,6 +20,7 @@ use \OCP\IConfig;
 	 * @method string getAvCmdOptions()
 	 * @method string getAvPath()
 	 * @method string getAvInfectedAction()
+	 * @method string getAvScanBackground()
 	 *
 	 * @method null setAvMode(string $avMode)
 	 * @method null setAvSocket(string $avsocket)
@@ -30,6 +31,7 @@ use \OCP\IConfig;
 	 * @method null setAvCmdOptions(string $avCmdOptions)
 	 * @method null setAvPath(string $avPath)
 	 * @method null setAvInfectedAction(string $avInfectedAction)
+	 * @method null setAvScanBackground(string $scanBackground)
 	 */
 
 class AppConfig {
@@ -48,6 +50,7 @@ class AppConfig {
 		'av_max_file_size' => -1,
 		'av_stream_max_length' => '26214400',
 		'av_infected_action' => 'only_log',
+		'av_scan_background' => 'true',
 	];
 
 	/**

--- a/lib/BackgroundScanner.php
+++ b/lib/BackgroundScanner.php
@@ -67,6 +67,11 @@ class BackgroundScanner {
 	 * @return null
 	 */
 	public function run(){
+
+		if ( $this->appConfig->getAvScanBackground() !== 'true') {
+			return;
+		}
+
 		// locate files that are not checked yet
 		try {
 			$result = $this->getFilesForScan();


### PR DESCRIPTION
# Motivation

When having user-key encryption enabled, running the background scan is not feasible, since it will just pollute the logs with messages like:

```
{
"reqId":"lzpZJJ71xtqk15b1iXBF",
"level":3,
"time":"2018-02-07T14:16:42+00:00"
,"remoteAddr":"",
"user":"admin",
"app":"files_antivirus",
"method":"--",
"url":"--",
"message":"OCA\\Files_Antivirus\\BackgroundScanner::run, exception: Can not decrypt this file, probably this is a shared file. Please ask the file owner to reshare the file with you."
}
```

This PR allows for disabling background scan by issuing: 
`occ config:app:set files_antivirus av_scan_background --value="false"`

