### PR TITLE
Fix final size detection for chunked uploads (dav v2 only)

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -13,17 +13,15 @@
 
 namespace OCA\Files_Antivirus\AppInfo;
 
-use \OCP\AppFramework\App;
-
 use OCA\Files_Antivirus\AppConfig;
+use OCA\Files_Antivirus\AvirWrapper;
 use OCA\Files_Antivirus\Controller\RuleController;
 use OCA\Files_Antivirus\Controller\SettingsController;
 use OCA\Files_Antivirus\Db\RuleMapper;
 use OCA\Files_Antivirus\BackgroundScanner;
 use OCA\Files_Antivirus\RequestHelper;
 use OCA\Files_Antivirus\ScannerFactory;
-
-use \OCA\Files_Antivirus\AvirWrapper;
+use OCP\AppFramework\App;
 
 class Application extends App {
 	public function __construct (array $urlParams = array()) {

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,6 +27,7 @@ More information is available in the Anti-Virus documentation.
 	</documentation>
 	<types>
 		<filesystem/>
+		<dav/>
 	</types>
 	<use-migrations>true</use-migrations>
 	<namespace>Files_Antivirus</namespace>
@@ -36,4 +37,12 @@ More information is available in the Anti-Virus documentation.
 	<settings>
 		<admin>OCA\Files_Antivirus\AdminPanel</admin>
 	</settings>
+	<background-jobs>
+		<job>OCA\Files_Antivirus\Cron\Task</job>
+	</background-jobs>
+	<sabre>
+		<plugins>
+			<plugin>OCA\Files_Antivirus\Dav\AntivirusPlugin</plugin>
+		</plugins>
+	</sabre>
 </info>

--- a/appinfo/install.php
+++ b/appinfo/install.php
@@ -16,4 +16,3 @@
 	'av_path',
 	'/usr/bin/clamscan'
 );
-\OC::$server->getJobList()->add('OCA\Files_Antivirus\Cron\Task');

--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -230,7 +230,7 @@ class AvirWrapper extends Wrapper{
 	 */
 	private function isScannableSize($path) {
 		$scanSizeLimit = \intval($this->appConfig->getAvMaxFileSize());
-		$size = $this->requestHelper->getUploadSize($path);
+		$size = $this->requestHelper->getUploadSize($this->storage, $path);
 
 		// No upload in progress. Skip this file.
 		if (\is_null($size)) {

--- a/lib/Dav/AntivirusPlugin.php
+++ b/lib/Dav/AntivirusPlugin.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * ownCloud - Files_antivirus
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Viktar Dubiniuk 2018
+ * @license AGPL-3.0
+ */
+
+namespace OCA\Files_Antivirus\Dav;
+
+use OCA\DAV\Upload\FutureFile;
+use OCA\Files_Antivirus\AppInfo\Application;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+
+/**
+ * Sabre plugin for the the antivirus
+ */
+class AntivirusPlugin extends ServerPlugin {
+	const NS_OWNCLOUD = 'http://owncloud.org/ns';
+
+	/**
+	 * @var \Sabre\DAV\Server $server
+	 */
+	private $server;
+
+	/**
+	 * @var Application
+	 */
+	private $application;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Application $application
+	 */
+	public function __construct(Application $application) {
+		$this->application = $application;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by Sabre\DAV\Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param Server $server
+	 *
+	 * @return void
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+		$this->server->on('beforeMove', [$this, 'beforeMove'], 1);
+	}
+
+	/**
+	 * @param string $source
+	 * @param string $destination
+	 *
+	 * @return bool|void
+	 * @throws \Sabre\DAV\Exception\NotFound
+	 */
+	public function beforeMove($source, $destination) {
+		$sourceNode = $this->server->tree->getNodeForPath($source);
+		if ($sourceNode instanceof FutureFile) {
+			$finalSize = $sourceNode->getSize();
+			$requestHelper = $this->application->getContainer()->query('RequestHelper');
+			$requestHelper->setSizeForPath($destination, $finalSize);
+		}
+		return true;
+	}
+}

--- a/tests/unit/RequestHelperTest.php
+++ b/tests/unit/RequestHelperTest.php
@@ -8,51 +8,120 @@
 
 namespace OCA\Files_Antivirus\Tests\unit;
 
+use OC\Files\Storage\Storage;
+use OCA\DAV\Upload\FutureFile;
+use OCA\Files_Antivirus\AppInfo\Application;
+use OCA\Files_Antivirus\Dav\AntivirusPlugin;
 use OCA\Files_Antivirus\RequestHelper;
 use \OCP\IRequest;
+use Sabre\DAV\Tree;
 
 class RequestHelperTest extends TestBase {
-	public function testPublicUploadSize() {
-		$size = 100;
-		$request = $this->getMockBuilder(IRequest::class)
+	/**
+	 * @var IRequest | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $request;
+
+	/**
+	 * @var \OC\Files\Storage\Storage | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $storage;
+
+	/**
+	 * @var string
+	 */
+	private $owner = 'anon';
+
+	public function setUp() {
+		parent::setUp();
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$request->expects($this->any())
+		$this->storage = $this->getMockBuilder(Storage::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->storage->expects($this->any())
+			->method('getOwner')
+			->willReturn($this->owner);
+	}
+
+	public function testPublicUploadSize() {
+		$size = 100;
+		$this->request->expects($this->any())
 			->method('getMethod')
 			->willReturn('PUT');
 
-		$request->expects($this->any())
+		$this->request->expects($this->any())
 			->method('getHeader')
 			->with('CONTENT_LENGTH')
 			->willReturn($size);
 
-		$request->expects($this->any())
+		$this->request->expects($this->any())
 			->method('getScriptName')
 			->willReturn('/somepath/public.php');
 
-		$requestHelper = new RequestHelper($request);
+		$requestHelper = new RequestHelper($this->request);
 
-		$uploadSize = $requestHelper->getUploadSize('/dummy');
+		$uploadSize = $requestHelper->getUploadSize(
+			$this->storage,
+			'/dummy'
+		);
 		$this->assertEquals($size, $uploadSize);
 	}
 
-	public function testChunkSkipped(){
-		$request = $this->getMockBuilder(IRequest::class)
-			->disableOriginalConstructor()
-			->getMock();
-
-		$request->expects($this->any())
+	public function testChunkSkipped() {
+		$this->request->expects($this->any())
 			->method('getMethod')
 			->willReturn('PUT');
 
-		$request->expects($this->any())
+		$this->request->expects($this->any())
 			->method('getScriptName')
 			->willReturn('/somepath/remote.php');
 
-		$requestHelper = new RequestHelper($request);
+		$requestHelper = new RequestHelper($this->request);
 
-		$uploadSize = $requestHelper->getUploadSize('uploads/iamachunk');
+		$uploadSize = $requestHelper->getUploadSize(
+			$this->storage,
+			'uploads/dummy'
+		);
 		$this->assertNull($uploadSize);
+	}
+
+	public function testCachedSize() {
+		$davPath = "files/$this->owner/fileName";
+		$movePath = "files/fileName";
+		$size = 1500;
+
+		$this->request->expects($this->any())
+			->method('getMethod')
+			->willReturn('MOVE');
+
+		$node = $this->getMockBuilder(FutureFile::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$node->expects($this->any())
+			->method('getSize')
+			->willReturn($size);
+
+		$tree = $this->createMock(Tree::class);
+		$tree->expects($this->any())
+			->method('getNodeForPath')
+			->willReturn($node);
+
+		$server = $this->createMock(\Sabre\DAV\Server::class);
+		$server->tree = $tree;
+
+		$plugin = new AntivirusPlugin(new Application());
+		$plugin->initialize($server);
+		$plugin->beforeMove('/something/.file', $davPath);
+
+		$requestHelper = new RequestHelper($this->request);
+		$requestHelper->setSizeForPath($davPath, $size);
+		$uploadSize = $requestHelper->getUploadSize(
+			$this->storage,
+			$movePath
+		);
+		$this->assertEquals($size, $uploadSize);
 	}
 }

--- a/tests/unit/StatusTest.php
+++ b/tests/unit/StatusTest.php
@@ -11,14 +11,12 @@ namespace OCA\Files_Antivirus\Tests\unit;
 use \OCA\Files_Antivirus\Db\RuleMapper;
 
 class StatusTest extends TestBase {
-	
 	// See OCA\Files_Antivirus\Status::init for details
 	const TEST_CLEAN = 0;
 	const TEST_INFECTED = 1;
 	const TEST_ERROR = 40;
 	
 	protected $ruleMapper;
-
 
 	public function setUp() {
 		parent::setUp();
@@ -27,7 +25,7 @@ class StatusTest extends TestBase {
 		$this->ruleMapper->populate();
 	}
 	
-	public function testParseResponse(){
+	public function testParseResponse() {
 		// Testing status codes
 		$testStatus = new \OCA\Files_Antivirus\Status();
 		
@@ -46,8 +44,7 @@ class StatusTest extends TestBase {
 		$failedScan = $testStatus->getNumericStatus();
 		$this->assertEquals(\OCA\Files_Antivirus\Status::SCANRESULT_UNCHECKED, $failedScan);
 		$this->assertEquals('Unknown option passed.', $testStatus->getDetails());
-		
-		
+
 		// Testing raw output (e.g. daemon mode)
 		// Empty content means result is unknown
 		$testStatus->parseResponse('');


### PR DESCRIPTION
Fixes #179 
Fixes https://github.com/owncloud/enterprise/issues/2145

1. set "File size limit" to 100bytes 
2. upload 3 chunks 40 bytes per chunk
```
user="USER"
pwd="PASSWORD"
host="HOST" # e.g. localhost
path="WEBPATH" # e.g. owncloud
chunk=1234

curl --user $user:$pwd http://$host/$path/remote.php/dav/uploads/$user/$chunk/ --request MKCOL
curl --user $user:$pwd http://$host/$path/remote.php/dav/uploads/$user/$chunk/1 --request PUT --data-binary "@eicar_com.txt_01"
curl --user $user:$pwd http://$host/$path/remote.php/dav/uploads/$user/$chunk/2 --request PUT --data-binary "@eicar_com.txt_02"
curl --user $user:$pwd http://$host/$path/remote.php/dav/uploads/$user/$chunk/3 --request PUT --data-binary "@eicar_com.txt_03"
curl --user $user:$pwd http://$host/$path/remote.php/dav/uploads/$user/$chunk/.file --request MOVE -H "Destination: http://$host/$path/remote.php/dav/files/$user/virus4"
```

### Expected 
`MOVE` request doesn't trigger scanning as 120 bytes are greater than 100
`{"reqId":"ZRjpwP2PYHuAx4Ld9eRi","level":0,"time":"2018-05-21T13:46:58+00:00","remoteAddr":"127.0.0.1","user":"D","app":"files_antivirus","method":"MOVE","url":"\/~deo\/oc-tmp\/remote.php\/dav\/uploads\/D\/117\/.file","message":"File size is 191. av_max_file_size is 100. Scanning is skipped."}
`

### Actual 
it does as file size is considered to be 0:
`{"reqId":"rLxp6i1qRUyv4yYZREhS","level":0,"time":"2018-05-21T14:32:46+00:00","remoteAddr":"127.0.0.1","user":"D","app":"files_antivirus","method":"MOVE","url":"\/~deo\/oc-tmp\/remote.php\/dav\/uploads\/D\/117\/.file","message":"File size is 0. av_max_file_size is 100. Scanning is scheduled."}`
