### PR TITLE
Run antivirus acceptance tests with log level warning

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirusMain.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusMain.feature
@@ -6,6 +6,7 @@ Feature: Antivirus basic
 
 	Background:
 		Given the administrator has enabled the files_antivirus app
+		And the owncloud log level has been set to warning
 		And the owncloud log has been cleared
 		And user "user0" has been created
 


### PR DESCRIPTION
which avoids getting "random excess" debug messages in the log.

files_antivirus logs its stuff nicely with log level warning.