### PR TITLE
Release/0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+## [0.13.0] - 2018-07-11
+### Fixed
+- Obey file size limits when uploads are chunked [#226](https://github.com/owncloud/files_antivirus/pull/226)
+- Don't log exceptions on virus detection [#219](https://github.com/owncloud/files_antivirus/pull/219)
+
+### Changed
+- Return HTTP status code `403` on virus detection [#219](https://github.com/owncloud/files_antivirus/pull/219)
+
 
 ## [0.12.0] - 2018-02-08
 
@@ -250,4 +258,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Initial implementation
 
+[Unreleased]: https://github.com/owncloud/files_antivirus/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/owncloud/files_antivirus/compare/v0.12.0...release/0.13.0
 [0.12.0]: https://github.com/owncloud/files_antivirus/compare/v0.11.2...release/0.12.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ More information is available in the Anti-Virus documentation.
 	<category>security</category>
 	<licence>AGPL</licence>
 	<author>Manuel Delgado, Bart Visscher, thinksilicon.de, Viktar Dubiniuk</author>
-	<version>0.12.0</version>
+	<version>0.13.0</version>
 	<documentation>
 		<admin>https://doc.owncloud.com/server/latest/admin_manual/configuration/server/antivirus_configuration.html</admin>
 	</documentation>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@ More information is available in the Anti-Virus documentation.
 	<use-migrations>true</use-migrations>
 	<namespace>Files_Antivirus</namespace>
 	<dependencies>
-		<owncloud min-version="10.0.8" max-version="11.0" />
+		<owncloud min-version="10.0.9" max-version="11.0" />
 	</dependencies>
 	<settings>
 		<admin>OCA\Files_Antivirus\AdminPanel</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@ More information is available in the Anti-Virus documentation.
 	<use-migrations>true</use-migrations>
 	<namespace>Files_Antivirus</namespace>
 	<dependencies>
-		<owncloud min-version="10.0.9" max-version="11.0" />
+		<owncloud min-version="10.0.9" max-version="10.1" />
 	</dependencies>
 	<settings>
 		<admin>OCA\Files_Antivirus\AdminPanel</admin>

--- a/lib/Item.php
+++ b/lib/Item.php
@@ -263,7 +263,7 @@ class Item implements IScannable {
 	 * @param string $path optional
 	 */
 	public function logError($message, $id=null, $path=null) {
-		$ownerInfo = $this->view === null ? '' : 'Account: ' . $this->view->getOwner($path);
+		$ownerInfo = $this->view === null ? '' : ' Account: ' . $this->view->getOwner($path);
 		$extra = ' File: ' . ($id === null ? $this->id : $id)
 				. $ownerInfo
 				. ' Path: ' . ($path === null ? $this->path : $path);

--- a/tests/acceptance/features/apiAntivirus/antivirusMain.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusMain.feature
@@ -40,7 +40,8 @@ Feature: Antivirus basic
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
-		Then as "user0" the file "/myChunkedFile.txt" should exist
+		Then the HTTP status code should be "200"
+		And as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: A small file with a virus cannot be uploaded in chunks using API version 1 and old DAV path
@@ -50,7 +51,8 @@ Feature: Antivirus basic
 			| 1 | This kitten |
 			| 2 | is a nasty  |
 			| 3 | virus       |
-		Then the last lines of the log file should contain log-entries containing these attributes:
+		Then the HTTP status code should be "403"
+		And the last lines of the log file should contain log-entries containing these attributes:
 			| user  | app             | method | message               |
 			| user0 | files_antivirus | PUT    | Infected file deleted |
 		And as "user0" the file "/myChunkedFile.txt" should not exist
@@ -62,7 +64,8 @@ Feature: Antivirus basic
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
-		Then as "user0" the file "/myChunkedFile.txt" should exist
+		Then the HTTP status code should be "201"
+		And as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 		Examples:
 			| api-version |
@@ -76,7 +79,8 @@ Feature: Antivirus basic
 			| 1 | This kitten |
 			| 2 | is a nasty  |
 			| 3 | virus       |
-		Then the last lines of the log file should contain log-entries containing these attributes:
+		Then the HTTP status code should be "403"
+		And the last lines of the log file should contain log-entries containing these attributes:
 			| user  | app             | method | message               |
 			| user0 | files_antivirus | MOVE   | Infected file deleted |
 		And as "user0" the file "/myChunkedFile.txt" should not exist


### PR DESCRIPTION
closes #221 

1) Bump version to ``0.13.0``
2) Add expected HTTP status codes to all acceptance test scenarios. Some scenarios already had these checks. It is good to have them in every scenario, so that we know if a status code changes.
3) Add another space in a log message, another place similar to #222 