### PR TITLE
Correct the expected old chunking status

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
@@ -49,12 +49,12 @@ Feature: Antivirus file size
 			| 1 | X5O!P%@AP[4\PZX54(P^)7C |
 			| 2 | C)7}$EICAR-STANDARD-ANT |
 			| 3 | IVIRUS-TEST-FILE!$H+H*  |
-		Then the HTTP status code should be "<http-status-code>"
+		Then the HTTP status code should be "201"
 		And as "user0" the file "/myChunkedFile.txt" should exist
 		Examples:
-			| dav-path-version | http-status-code |
-			| old              | 200              |
-			| new              | 201              |
+			| dav-path-version |
+			| old              |
+			| new              |
 
 	Scenario: Files smaller than the upload threshold are checked for viruses when uploaded via public upload
 		Given as user "user0"

--- a/tests/acceptance/features/apiAntivirus/antivirusMain.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusMain.feature
@@ -54,13 +54,13 @@ Feature: Antivirus basic
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
-		Then the HTTP status code should be "<http-status-code>"
+		Then the HTTP status code should be "201"
 		And as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 		Examples:
-			| dav-path-version | http-status-code |
-			| old              | 200              |
-			| new              | 201              |
+			| dav-path-version |
+			| old              |
+			| new              |
 
 	Scenario Outline: A small file with a virus cannot be uploaded in chunks
 		Given using <dav-path-version> DAV path


### PR DESCRIPTION
The acceptance test code was fixed in core, so now the old chunking upload status is correct (201) and matches the new chunking status code.

Well done for finding and fixing that in core yesterday @individual-it 