### PR TITLE
Remove leftover lint in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,6 @@ test-php-codecheck:
 	$(occ) app:check-code $(app_name) -c private -c strong-comparison
 	$(occ) app:check-code $(app_name) -c deprecation
 
-.PHONY: test-php-lint
-test-php-lint:
-	../../lib/composer/bin/parallel-lint . --exclude 3rdparty --exclude build .
-
 #
 # Dependency management
 #--------------------------------------


### PR DESCRIPTION
Fixes #282 

The ``lint`` program is no longer in ``composer.json`` and is not run in drone.

Remove the bit of useless lint target in ``Makefile``