### PR TITLE
Change invokingTheCommand to runOcc

### DIFF
--- a/tests/acceptance/features/bootstrap/AntivirusContext.php
+++ b/tests/acceptance/features/bootstrap/AntivirusContext.php
@@ -62,9 +62,9 @@ class AntivirusContext implements Context {
 	 */
 	public function theAdministratorEnablesTheAntivirusApp($enableDisable) {
 		if (($enableDisable === "enables") || ($enableDisable === "has enabled")) {
-			$this->featureContext->invokingTheCommand("app:enable files_antivirus");
+			$this->featureContext->runOcc(["app:enable files_antivirus"]);
 		} else {
-			$this->featureContext->invokingTheCommand("app:disable files_antivirus");
+			$this->featureContext->runOcc(["app:disable files_antivirus"]);
 		}
 	}
 


### PR DESCRIPTION
``invokingTheCommand`` just calls ``runOcc`` directly anyway.

https://github.com/owncloud/core/pull/34127 is going to move ``invokingTheCommand`` out of ``FeatureContext`` so ``invokingTheCommand`` will not be there any more.