### PR TITLE
Remove duplicate and old composer_deps and composer_dev_deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,6 @@ appstore_build_directory=$(CURDIR)/build/artifacts/appstore
 appstore_package_name=$(appstore_build_directory)/$(app_name)
 
 # composer
-composer_deps=vendor
-composer_dev_deps=vendor/php-cs-fixer
 acceptance_test_deps=vendor-bin/behat/vendor
 
 # signing
@@ -51,15 +49,6 @@ clean: clean-composer-deps
 .PHONY: clean-composer-deps
 clean-composer-deps:
 	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
-
-#
-# ownCloud core PHP dependencies
-#
-$(composer_deps): $(COMPOSER_BIN) composer.json composer.lock
-	php $(COMPOSER_BIN) install --no-dev
-
-$(composer_dev_deps): $(COMPOSER_BIN) composer.json composer.lock
-	php $(COMPOSER_BIN) install --dev
 
 # Builds the source and appstore package
 .PHONY: dist


### PR DESCRIPTION
``vendor`` dependency is already down the end of the ``Makefile`` in the "Dependency management" section.
``php-cs-fixer`` is part of owncloud codestyle, it actually does not live inside ``vendor`` any more.

Before this change:
```
make
Makefile:166: warning: overriding recipe for target 'vendor'
Makefile:59: warning: ignoring old recipe for target 'vendor'
```
This PR gets rid of those warnings.