### PR TITLE
Add extra expected log file exception message for antivirusFileSize.feature:45

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
@@ -57,6 +57,7 @@ Feature: Antivirus file size
       | user  | app               | message               |
       | user0 | files_antivirus   | Infected file deleted |
       | user0 | no app in context | Exception             |
+      | user0 | no app in context | Exception             |
     And as "user0" file "/myChunkedFile.txt" should not exist
 
   Scenario Outline: Files bigger than the upload threshold are not checked for viruses when using chunking


### PR DESCRIPTION
Issue #295 
When uploading with chunking, there is now the usual "Infected file deleted" message, but there are 2 exception messages logged. So we need to list both of those, so that the more interesting "Infected file deleted" message is found as the 3rd-last message in the log file.