### PR TITLE
Use only 1 var in when matrix of drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -478,23 +478,6 @@ matrix:
       DB_USERNAME: admin
       DB_PASSWORD: secret
 
-  # objectstore related
-
-    - PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiAntivirus
-      NEED_CORE: true
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-      NEED_CLAMAV: true
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      DB_NAME: oc_db
-      DB_USERNAME: admin
-      DB_PASSWORD: secret
-      TEST_OBJECTSTORAGE: true
-
   # activity app related
 
     - PHP_VERSION: 7.1

--- a/.drone.yml
+++ b/.drone.yml
@@ -218,7 +218,6 @@ services:
       - MYSQL_ROOT_PASSWORD=secret
     when:
       matrix:
-        DB_TYPE: mysql
         DB_HOST: mysql
 
   mysqlmb4:
@@ -230,7 +229,6 @@ services:
       - MYSQL_ROOT_PASSWORD=secret
     when:
       matrix:
-        DB_TYPE: mysql
         DB_HOST: mysqlmb4
 
   pgsql:


### PR DESCRIPTION
1) The new drone tries to auto-convert the old drone format. It seems that when there are multiple variables mentioned in the `when` section of a step, it it doing something in the auto-conversion that causes:
https://drone.owncloud.com/owncloud/files_antivirus/824
`linter: duplicate step names`

I guess that it might be putting the step twice into the converted matrix.

The changes in this PR work-around the "feature".

2) This is the same scality problem as https://github.com/owncloud/core/issues/36002
Remove the scality test matrix for now.
(and put it back when the core issue is resolved)