### PR TITLE
Run API acceptance tests on both scality and ceph

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -67,10 +67,14 @@ config = {
 				'oracle'
 			],
 		},
-		'api-objectstore': {
+		'api-scality': {
 			'suites': {
-				'apiAntivirus': 'apiAntivirusObjectstore',
+				'apiAntivirus': 'apiAvScality',
 			},
+			'servers': [
+				'daily-master-qa',
+				'10.3.0alpha2'
+			],
 			'databases': [
 				'mariadb:10.2',
 			],
@@ -103,6 +107,54 @@ config = {
 					'pull': 'always',
 					'environment': {
 						'HOST_NAME': 'scality'
+					}
+				}
+			]
+		},
+		'api-ceph': {
+			'suites': {
+				'apiAntivirus': 'apiAvCeph',
+			},
+			'servers': [
+				'daily-master-qa',
+				'10.3.0alpha2'
+			],
+			'databases': [
+				'mariadb:10.2',
+			],
+			'extraApps': {
+				'files_primary_s3': 'composer install'
+			},
+			'extraSetup': {
+				'name': 'configure-app',
+				'image': 'owncloudci/php:7.0',
+				'pull': 'always',
+				'commands': [
+					'cd /var/www/owncloud/server/apps/files_primary_s3',
+					'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
+					'cd /var/www/owncloud/server',
+					'php occ config:app:set --value "clamav" files_antivirus av_host',
+					'php occ config:app:set --value "daemon" files_antivirus av_mode',
+					'php occ config:app:set --value "3310" files_antivirus av_port',
+				]
+			},
+			'extraServices': [
+				{
+					'name': 'clamav',
+					'image': 'dinkel/clamavd',
+					'pull': 'always',
+				},
+				{
+					'name': 'ceph',
+					'image': 'ceph/daemon:v3.0.7-stable-3.0-jewel-ubuntu-16.04-x86_64',
+					'pull': 'always',
+					'environment': {
+						'NETWORK_AUTO_DETECT': '4',
+						'CEPH_DAEMON': 'demo',
+						'RGW_NAME': 'ceph',
+						'CEPH_DEMO_UID': 'owncloud',
+						'CEPH_DEMO_ACCESS_KEY': 'owncloud123456',
+						'CEPH_DEMO_SECRET_KEY': 'secret123456',
 					}
 				}
 			]

--- a/.drone.yml
+++ b/.drone.yml
@@ -3066,7 +3066,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAntivirusObjectstore-master-mariadb10.2-php7.0
+name: apiAvScality-master-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3216,7 +3216,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAntivirusObjectstore-latest-mariadb10.2-php7.0
+name: apiAvScality-10.3.0alpha2-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3238,7 +3238,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/files_antivirus
-    version: latest
+    version: 10.3.0alpha2
 
 - name: install-testrunner
   pull: always
@@ -3366,6 +3366,314 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: apiAvCeph-master-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/files_antivirus
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/files_antivirus
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/files_antivirus /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-files_antivirus
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/files_antivirus
+  - make
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/files_primary_s3.git /var/www/owncloud/testrunner/apps/files_primary_s3
+  - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/server/apps/files_primary_s3
+  - composer install
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e files_primary_s3
+  - php occ a:l
+
+- name: setup-server-files_antivirus
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e files_antivirus
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/files_primary_s3
+  - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
+  - cd /var/www/owncloud/server
+  - php occ config:app:set --value "clamav" files_antivirus av_host
+  - php occ config:app:set --value "daemon" files_antivirus av_mode
+  - php occ config:app:set --value "3310" files_antivirus av_port
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiAntivirus
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: clamav
+  pull: always
+  image: dinkel/clamavd
+
+- name: ceph
+  pull: always
+  image: ceph/daemon:v3.0.7-stable-3.0-jewel-ubuntu-16.04-x86_64
+  environment:
+    CEPH_DAEMON: demo
+    CEPH_DEMO_ACCESS_KEY: owncloud123456
+    CEPH_DEMO_SECRET_KEY: secret123456
+    CEPH_DEMO_UID: owncloud
+    NETWORK_AUTO_DETECT: 4
+    RGW_NAME: ceph
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiAvCeph-10.3.0alpha2-mariadb10.2-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/files_antivirus
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/files_antivirus
+    version: 10.3.0alpha2
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/files_antivirus /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-app-files_antivirus
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/files_antivirus
+  - make
+
+- name: install-extra-apps
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - git clone https://github.com/owncloud/files_primary_s3.git /var/www/owncloud/testrunner/apps/files_primary_s3
+  - cp -r /var/www/owncloud/testrunner/apps/files_primary_s3 /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/server/apps/files_primary_s3
+  - composer install
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e files_primary_s3
+  - php occ a:l
+
+- name: setup-server-files_antivirus
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e files_antivirus
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server/apps/files_primary_s3
+  - cp tests/drone/ceph.config.php /var/www/owncloud/server/config
+  - cd /var/www/owncloud/server
+  - php occ config:app:set --value "clamav" files_antivirus av_host
+  - php occ config:app:set --value "daemon" files_antivirus av_mode
+  - php occ config:app:set --value "3310" files_antivirus av_port
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiAntivirus
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: clamav
+  pull: always
+  image: dinkel/clamavd
+
+- name: ceph
+  pull: always
+  image: ceph/daemon:v3.0.7-stable-3.0-jewel-ubuntu-16.04-x86_64
+  environment:
+    CEPH_DAEMON: demo
+    CEPH_DEMO_ACCESS_KEY: owncloud123456
+    CEPH_DEMO_SECRET_KEY: secret123456
+    CEPH_DEMO_UID: owncloud
+    NETWORK_AUTO_DETECT: 4
+    RGW_NAME: ceph
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- coding-standard-php7.1
+- coding-standard-php7.2
+- coding-standard-php7.3
+
+---
+kind: pipeline
+type: docker
 name: chat-notifications
 
 platform:
@@ -3416,7 +3724,9 @@ depends_on:
 - apiAntivirus-latest-mysql5.7-php7.0
 - apiAntivirus-latest-postgres9.4-php7.0
 - apiAntivirus-latest-oracle-php7.0
-- apiAntivirusObjectstore-master-mariadb10.2-php7.0
-- apiAntivirusObjectstore-latest-mariadb10.2-php7.0
+- apiAvScality-master-mariadb10.2-php7.0
+- apiAvScality-10.3.0alpha2-mariadb10.2-php7.0
+- apiAvCeph-master-mariadb10.2-php7.0
+- apiAvCeph-10.3.0alpha2-mariadb10.2-php7.0
 
 ...


### PR DESCRIPTION
Some app repos test objectstore with scality and some with ceph.
Actually we can be more sure, and run the tests on both.

Also, `files_primary_s3` `master` has been bumped to require core min version `10.3`. So when testing with `files_primary_s3` we cannot use core `latest` = `10.2.1` any more. So  that has also been adjusted to use `10.3.0alpha2`.