### PR TITLE
No need to test against 10.3.0 any more

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -73,7 +73,7 @@ config = {
 			},
 			'servers': [
 				'daily-master-qa',
-				'10.3.0'
+				'latest'
 			],
 			'databases': [
 				'mariadb:10.2',
@@ -106,7 +106,7 @@ config = {
 			},
 			'servers': [
 				'daily-master-qa',
-				'10.3.0'
+				'latest'
 			],
 			'databases': [
 				'mariadb:10.2',

--- a/.drone.yml
+++ b/.drone.yml
@@ -3225,7 +3225,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAvScality-10.3.0-mariadb10.2-php7.0
+name: apiAvScality-latest-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3247,7 +3247,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/files_antivirus
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -3547,7 +3547,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiAvCeph-10.3.0-mariadb10.2-php7.0
+name: apiAvCeph-latest-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3569,7 +3569,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/files_antivirus
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -3764,8 +3764,8 @@ depends_on:
 - apiAntivirus-latest-postgres9.4-php7.0
 - apiAntivirus-latest-oracle-php7.0
 - apiAvScality-master-mariadb10.2-php7.0
-- apiAvScality-10.3.0-mariadb10.2-php7.0
+- apiAvScality-latest-mariadb10.2-php7.0
 - apiAvCeph-master-mariadb10.2-php7.0
-- apiAvCeph-10.3.0-mariadb10.2-php7.0
+- apiAvCeph-latest-mariadb10.2-php7.0
 
 ...


### PR DESCRIPTION
The download link `latest` now points to the recent `10.3.0` release tarball. So test against latest.