### PR TITLE
Fix failing tests for public webDAV API step

### DIFF
--- a/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
@@ -87,8 +87,9 @@ Feature: Antivirus file size
       | status | /^finished$/      |
     And as "user0" file "/myChunkedFile.txt" should exist
 
-  Scenario: Files smaller than the upload threshold are checked for viruses when uploaded via public upload
-    Given as user "user0"
+  Scenario: Files smaller than the upload threshold are checked for viruses when uploaded via old public upload
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And user "user0" has created a public link share of folder "FOLDER" with change permissions
     And parameter "av_max_file_size" of app "files_antivirus" has been set to "100"
     When the public uploads file "eicar.com" from the antivirus test data folder using the old WebDAV API
@@ -98,13 +99,31 @@ Feature: Antivirus file size
       | --   | files_antivirus | PUT    | Infected file deleted |
     And as "user0" file "/FOLDER/eicar.com" should not exist
 
-  Scenario: Files bigger than the upload threshold are not checked for viruses when uploaded via public upload
-    Given as user "user0"
+  @skip @issue-334
+  Scenario: Files smaller than the upload threshold are checked for viruses when uploaded via new public upload
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And user "user0" has created a public link share of folder "FOLDER" with change permissions
     And parameter "av_max_file_size" of app "files_antivirus" has been set to "100"
-    When the public uploads file "eicar_com.zip" from the antivirus test data folder using the old WebDAV API
+    When the public uploads file "eicar.com" from the antivirus test data folder using the new WebDAV API
+    Then the HTTP status code should be "403"
+    And the last lines of the log file should contain log-entries containing these attributes:
+      | user | app             | method | message               |
+      | --   | files_antivirus | PUT    | Infected file deleted |
+    And as "user0" file "/FOLDER/eicar.com" should not exist
+
+  Scenario Outline: Files bigger than the upload threshold are not checked for viruses when uploaded via public upload
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
+    And user "user0" has created a public link share of folder "FOLDER" with change permissions
+    And parameter "av_max_file_size" of app "files_antivirus" has been set to "100"
+    When the public uploads file "eicar_com.zip" from the antivirus test data folder using the <public-webdav-api> WebDAV API
     Then the HTTP status code should be "201"
     And as "user0" file "/FOLDER/eicar_com.zip" should exist
+    Examples:
+      | public-webdav-api |
+      | new               |
+      | old               |
 
   @skip @files_primary_s3#69
   Scenario: Files smaller than the upload threshold are checked for viruses when uploaded overwriting via public upload
@@ -119,11 +138,16 @@ Feature: Antivirus file size
       | --   | files_antivirus | PUT    | Infected file deleted |
     And the content of file "/FOLDER/textfile.txt" for user "user0" should be "Small text file without virus."
 
-  Scenario: Files bigger than the upload threshold are not checked for viruses when uploaded overwriting via public upload
-    Given as user "user0"
+  Scenario Outline: Files bigger than the upload threshold are not checked for viruses when uploaded overwriting via public upload
+    Given the administrator has enabled DAV tech_preview
+    And as user "user0"
     And user "user0" has created a public link share of folder "FOLDER" with change permissions
     And parameter "av_max_file_size" of app "files_antivirus" has been set to "60"
-    When the public uploads file "textfile.txt" from the antivirus test data folder using the old WebDAV API
+    When the public uploads file "textfile.txt" from the antivirus test data folder using the <public-webdav-api> WebDAV API
     And the public overwrites file "textfile.txt" with content "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" using the old WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/FOLDER/textfile.txt" for user "user0" should be "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+    Examples:
+      | public-webdav-api |
+      | new               |
+      | old               |

--- a/tests/acceptance/features/bootstrap/AntivirusContext.php
+++ b/tests/acceptance/features/bootstrap/AntivirusContext.php
@@ -86,16 +86,17 @@ class AntivirusContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" from the antivirus test data folder using the old WebDAV API
+	 * @When /^the public uploads file "([^"]*)" from the antivirus test data folder using the (new|old) WebDAV API$/
 	 * @Given the public has uploaded file ":filename" from the antivirus test data folder
 	 *
 	 * @param string $source target file name
+	 * @param string $publicWebDavAPIVersion
 	 *
 	 * @return void
 	 */
-	public function publicUploadsFileFromAntivirusDataFolder($source) {
+	public function publicUploadsFileFromAntivirusDataFolder($source, $publicWebDavAPIVersion = "old") {
 		$source = $this->getRelativePathToTestDataFolder() . $source;
-		$this->publicWebDavContext->publiclyUploadingFile($source);
+		$this->publicWebDavContext->publiclyUploadingFile($source, $publicWebDavAPIVersion);
 	}
 
 	/**


### PR DESCRIPTION
Fix for failing tests in drone due to core code change.
https://drone.owncloud.com/owncloud/files_antivirus/972/21/12


Also add new scenarios for new public webDAV API