### PR TITLE
wait for clamav in all configure-app steps

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -118,6 +118,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
+						'wait-for-it -t 60 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',
@@ -173,6 +174,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
+						'wait-for-it -t 60 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',

--- a/.drone.yml
+++ b/.drone.yml
@@ -1060,6 +1060,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1206,6 +1207,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1353,6 +1355,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1499,6 +1502,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1635,6 +1639,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1760,6 +1765,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1885,6 +1891,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2010,6 +2017,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2134,6 +2142,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2259,6 +2268,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2384,6 +2394,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2509,6 +2520,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2634,6 +2646,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2758,6 +2771,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -3220,6 +3234,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -3380,6 +3395,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
+  - wait-for-it -t 60 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port


### PR DESCRIPTION
Issue #340 

There was another drone CI  fail last night due to clamav not really being ready - https://drone.owncloud.com/owncloud/files_antivirus/1058/23/12
```
  Scenario: Files smaller than the upload threshold are checked for viruses                                                 # /var/www/owncloud/testrunner/apps/files_antivirus/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature:13
    Given parameter "av_max_file_size" of app "files_antivirus" has been set to "100"                                       # FeatureContext::serverParameterHasBeenSetTo()
    When user "user0" uploads file "eicar.com" from the antivirus test data folder to "/virusfile.txt" using the WebDAV API # AntivirusContext::userUploadsFileFromAntivirusDataFolderTo()
    Then the HTTP status code should be "403"                                                                               # FeatureContext::theHTTPStatusCodeShouldBe()
      HTTP status code is not the expected value
      Failed asserting that 201 matches expected '403'.
```

PR #342 added some `wait-for-it -t 60 clamav:3310` but not to every pipeline.

Add the wait in other acceptance test pipelines.