### PR TITLE
Change docker image which waits for virus db update, increase wait

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -84,7 +84,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
-						'wait-for-it -t 60 clamav:3310',
+						'wait-for-it -t 300 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',
@@ -94,7 +94,7 @@ config = {
 			'extraServices': [
 				{
 					'name': 'clamav',
-					'image': 'dinkel/clamavd',
+					'image': 'jankaritechnepal/clamavd',
 					'pull': 'always',
 				},
 			]
@@ -118,7 +118,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
-						'wait-for-it -t 60 clamav:3310',
+						'wait-for-it -t 300 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',
@@ -128,7 +128,7 @@ config = {
 			'extraServices': [
 				{
 					'name': 'clamav',
-					'image': 'dinkel/clamavd',
+					'image': 'jankaritechnepal/clamavd',
 					'pull': 'always',
 				},
 			]
@@ -174,7 +174,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
-						'wait-for-it -t 60 clamav:3310',
+						'wait-for-it -t 300 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',
@@ -184,7 +184,7 @@ config = {
 			'extraServices': [
 				{
 					'name': 'clamav',
-					'image': 'dinkel/clamavd',
+					'image': 'jankaritechnepal/clamavd',
 					'pull': 'always',
 				}
 			]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1060,7 +1060,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1104,7 +1104,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -1207,7 +1207,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1252,7 +1252,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -1355,7 +1355,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1399,7 +1399,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -1502,7 +1502,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1547,7 +1547,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -1639,7 +1639,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1673,7 +1673,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -1765,7 +1765,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1799,7 +1799,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -1891,7 +1891,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -1925,7 +1925,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2017,7 +2017,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2050,7 +2050,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2142,7 +2142,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2176,7 +2176,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2268,7 +2268,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2302,7 +2302,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2394,7 +2394,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2428,7 +2428,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2520,7 +2520,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2554,7 +2554,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2646,7 +2646,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2679,7 +2679,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2771,7 +2771,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2805,7 +2805,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -2920,7 +2920,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -2962,7 +2962,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -3077,7 +3077,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -3119,7 +3119,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -3234,7 +3234,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -3280,7 +3280,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always
@@ -3395,7 +3395,7 @@ steps:
   image: owncloudci/php:7.1
   commands:
   - cd /var/www/owncloud/server
-  - wait-for-it -t 60 clamav:3310
+  - wait-for-it -t 300 clamav:3310
   - php occ config:app:set --value "clamav" files_antivirus av_host
   - php occ config:app:set --value "daemon" files_antivirus av_mode
   - php occ config:app:set --value "3310" files_antivirus av_port
@@ -3441,7 +3441,7 @@ services:
 
 - name: clamav
   pull: always
-  image: dinkel/clamavd
+  image: jankaritechnepal/clamavd
 
 - name: server
   pull: always


### PR DESCRIPTION
I have changed the docker image to be `skshetry/clamavd`, which is available in https://github.com/JankariTech/docker-clamavd/pull/1, and increased the wait time to 5 minutes (doesn't really hurt).

~I also noticed, that there is a certain time for clamavd to get ready. So, I added a script, so, as to wait for   `clamavd` to respond for `nSTATS` command~.

~This should make it more reliable~.

Related issue #340