### PR TITLE
Adjust expected activity message for infected file

### DIFF
--- a/tests/acceptance/features/webUIActivityList/activityList.feature
+++ b/tests/acceptance/features/webUIActivityList/activityList.feature
@@ -13,10 +13,10 @@ Feature: log activities of blocked files
     And user "user1" has uploaded file "eicar.com" from the antivirus test data folder to "/new-file.txt"
     When the user browses to the activity page
     Then the activity number 1 should contain message "File files/new-file.txt" in the activity page
-    And the activity number 1 should contain message "is infected with Eicar-Test-Signature" in the activity page
+    And the activity number 1 should contain message "is infected with" in the activity page
     When the user filters activity list by "Antivirus"
     Then the activity number 1 should contain message "File files/new-file.txt" in the activity page
-    And the activity number 1 should contain message "is infected with Eicar-Test-Signature" in the activity page
+    And the activity number 1 should contain message "is infected with" in the activity page
     And the activity should not have any message with keyword "create"
     Examples:
       | dav-path-version |
@@ -28,11 +28,11 @@ Feature: log activities of blocked files
     And user "user1" has uploaded file "eicar.com" from the antivirus test data folder to "lorem.txt"
     When the user browses to the activity page
     Then the activity number 1 should contain message "File files/lorem.txt" in the activity page
-    And the activity number 1 should contain message "is infected with Eicar-Test-Signature" in the activity page
+    And the activity number 1 should contain message "is infected with" in the activity page
     And the activity should not have any message with keyword "change"
     When the user filters activity list by "Antivirus"
     Then the activity number 1 should contain message "File files/lorem.txt" in the activity page
-    And the activity number 1 should contain message "is infected with Eicar-Test-Signature" in the activity page
+    And the activity number 1 should contain message "is infected with" in the activity page
     And the activity should not have any message with keyword "change"
     Examples:
       | dav-path-version |


### PR DESCRIPTION
Fixes issue #356 

CI started reporting `is infected with Clamav.Test.File-7` instead of `is infected with Eicar-Test-Signature`. Actually the clamav file `Clamav.Test.File-7` is the Eicar test file. In CI the Clamav database is automagically update before the CI run, so we get an up-to-date database each CI  run. That means that Clamav could change the detail of what they report as the "virus" that has been detected.

For these tests, we only care that some virus has been detected, not the exact name of the "virus".

Make the test expectation not depend on the exact name of the virus.