### PR TITLE
Add AppConfigurationContext to apiAntivirus contexts

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -14,6 +14,7 @@ default:
             adminPassword: admin
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
+        - AppConfigurationContext:
         - LoggingContext:
         - OccContext:
         - PublicWebDavContext:


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/files_antivirus/1156/20/12
```
--- FeatureContext has missing steps. Define them with these snippets:

    /**
     * @Given parameter :arg1 of app :arg2 has been set to :arg3
     */
    public function parameterOfAppHasBeenSetTo($arg1, $arg2, $arg3)
    {
        throw new PendingException();
    }
```
This is only happening in the report of skipped scenarios. In the ordinary test suite run, `FeatureContext` gets `AppConfigurationContext` in `BeforeScenario` and so the scenario finds the steps it needs in `AppConfigurationContext` anyway.

We may as well put `AppConfigurationContext`  in `behat.yml` because it really is a needed context.