### PR TITLE
[Tests-Only] Adjust wait for clamav docker to pull

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -84,7 +84,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
-						'wait-for-it -t 300 clamav:3310',
+						'wait-for-it -t 600 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',
@@ -118,7 +118,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
-						'wait-for-it -t 300 clamav:3310',
+						'wait-for-it -t 600 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',
@@ -233,7 +233,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'cd /var/www/owncloud/server',
-						'wait-for-it -t 300 clamav:3310',
+						'wait-for-it -t 600 clamav:3310',
 						'php occ config:app:set --value "clamav" files_antivirus av_host',
 						'php occ config:app:set --value "daemon" files_antivirus av_mode',
 						'php occ config:app:set --value "3310" files_antivirus av_port',


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/files_antivirus/1373/49/3

The docker image was taking a long time to pull. It caused a test fail last night. Usually these days we wait up to 10 minutes (600 seconds) for this sort of thing. So increase the wait here to 600 seconds to be consistent.