### PR TITLE
Adjust PHP dependencies for composer 2.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1052,7 +1052,7 @@ def acceptance():
 									},
 									'steps':
 										installCore(server, db, params['useBundledApp']) +
-										installTestrunner(phpVersion, params['useBundledApp']) +
+										installTestrunner('7.4', params['useBundledApp']) +
 										(installFederated(server, phpVersion, params['logLevel'], db, federationDbSuffix) + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
 										installApp(phpVersion) +
 										installExtraApps(phpVersion, params['extraApps']) +
@@ -1065,7 +1065,7 @@ def acceptance():
 									[
 										({
 											'name': 'acceptance-tests',
-											'image': 'owncloudci/php:%s' % phpVersion,
+											'image': 'owncloudci/php:7.4',
 											'pull': 'always',
 											'environment': environment,
 											'commands': params['extraCommandsBeforeTestRun'] + [

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,10 +7,10 @@ When talking about file sharing, one aspect is key: Security. But security not o
 The ownCloud Anti-Virus application forwards files that are being uploaded to the ownCloud server to an external malware scanning engine before they are written to the storage. When a file is identified to be malicious, it can either be logged or be prevented from being uploaded to the server to ensure that files in ownCloud are free of malware.
 Additionally more sophisticated rules may be specified in 'Advanced' mode. ownCloud administrators can find the configuration options in the 'Security' settings section.
 
-ClamAV is the officially supported virus scanner available for use with ownCloud. It detects all forms of malware including trojans, viruses, and worms and scans compressed files, executables, image files, PDF, as well as many other file types. 
-The ownCloud Anti-Virus application relies on the underlying ClamAV virus scanning engine, which the admin points ownCloud to when configuring the application. The ClamAV virus definitions should always be kept up to date in order to provide effective protection. 
+ClamAV is the officially supported virus scanner available for use with ownCloud. It detects all forms of malware including trojans, viruses, and worms and scans compressed files, executables, image files, PDF, as well as many other file types.
+The ownCloud Anti-Virus application relies on the underlying ClamAV virus scanning engine, which the admin points ownCloud to when configuring the application. The ClamAV virus definitions should always be kept up to date in order to provide effective protection.
 
-Please note that enabling this application will impact system performance as additional processing is required for every file upload. 
+Please note that enabling this application will impact system performance as additional processing is required for every file upload.
 More information is available in the Anti-Virus documentation.
 	</description>
 	<bugs>https://github.com/owncloud/files_antivirus/issues</bugs>
@@ -32,7 +32,7 @@ More information is available in the Anti-Virus documentation.
 	<use-migrations>true</use-migrations>
 	<namespace>Files_Antivirus</namespace>
 	<dependencies>
-		<owncloud min-version="10.2.0" max-version="10" />
+		<owncloud min-version="10.3" max-version="10" />
 	</dependencies>
 	<settings>
 		<admin>OCA\Files_Antivirus\AdminPanel</admin>

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "deed77c6cbecc6d46326aa9f6e3fc79a",
@@ -51,6 +51,10 @@
                 "isolation",
                 "tool"
             ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+            },
             "time": "2020-05-03T08:27:20+00:00"
         }
     ],
@@ -63,5 +67,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    }
+    },
+    "plugin-api-version": "2.0.0"
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "7.2"
+            "php": "7.4"
         }
     },
     "require": {


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/38067

See issue for details - `behat` acceptance tests need to use PHP  7.4 for the dependencies to sort themselves out with composer 2.0

And adjusting owncloud min-version="10.3" because we want to ensure PHP 7.1 and... - it would require a bunch of extra testing to ensure that we could run the latest encryption app code with ownCloud 10.2 and PHP 7.0