### PR TITLE
Prefer daemon or socket to executable mode to if any of those is available

### DIFF
--- a/appinfo/install.php
+++ b/appinfo/install.php
@@ -7,12 +7,12 @@
  *
  * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
  *
- * @copyright Viktar Dubiniuk 2014-2018
+ * @copyright Viktar Dubiniuk 2021
  * @license AGPL-3.0
  */
 
-\OC::$server->getConfig()->setAppValue(
-	'files_antivirus',
-	'av_path',
-	'/usr/bin/clamscan'
-);
+$passed = \OC::$server->getConfig()->getAppValue('files_antivirus', 'autoprobe', false);
+if ($passed === false) {
+	$app = new \OCA\Files_Antivirus\AppInfo\Application();
+	$app->autoProbe();
+}

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -7,7 +7,7 @@
  *
  * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
  *
- * @copyright Viktar Dubiniuk 2015-2018
+ * @copyright Viktar Dubiniuk 2021
  * @license AGPL-3.0
  */
 
@@ -54,8 +54,8 @@ class AppConfig {
 	private $defaults = [
 		'av_mode' => 'executable',
 		'av_socket' => '/var/run/clamav/clamd.ctl',
-		'av_host' => '',
-		'av_port' => '',
+		'av_host' => 'localhost',
+		'av_port' => '3310',
 		'av_cmd_options' => '',
 		'av_path' => '/usr/bin/clamscan',
 		'av_max_file_size' => -1,


### PR DESCRIPTION
After the app is enabled **for the first time** we check the default port and default socket. If clamav detects eicar using any of those we use this mode as a default. Otherwise  the executable mode is used as before.

Note: This is done **only once** - after the app is enabled **for the first time.**

Closes https://github.com/owncloud/files_antivirus/issues/396