### PR TITLE
[tests-only] Test with mysql 8.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -403,7 +403,7 @@ def jscodestyle():
 		'steps': [
 			{
 				'name': 'coding-standard-js',
-				'image': 'owncloudci/php:7.2',
+				'image': 'owncloudci/php:8.0',
 				'pull': 'always',
 				'commands': [
 					'make test-js-style'
@@ -708,13 +708,13 @@ def javascript(ctx):
 		},
 		'steps':
 			installCore('daily-master-qa', 'sqlite', False) +
-			installApp('7.2') +
-			setupServerAndApp('7.2', params['logLevel']) +
+			installApp('7.4') +
+			setupServerAndApp('7.4', params['logLevel']) +
 			params['extraSetup'] +
 		[
 			{
 				'name': 'js-tests',
-				'image': 'owncloudci/php:7.2',
+				'image': 'owncloudci/php:8.0',
 				'pull': 'always',
 				'environment': params['extraEnvironment'],
 				'commands': params['extraCommandsBeforeTestRun'] + [
@@ -1798,7 +1798,7 @@ def databaseServiceForFederation(db, suffix):
 		print('Not implemented federated database for ', dbName)
 		return []
 
-	return [{
+	service = {
 		'name': dbName + suffix,
 		'image': db,
 		'pull': 'always',
@@ -1808,7 +1808,10 @@ def databaseServiceForFederation(db, suffix):
 			'MYSQL_DATABASE': getDbDatabase(db) + suffix,
 			'MYSQL_ROOT_PASSWORD': getDbRootPassword()
 		}
-	}]
+	}
+	if (db == 'mysql:8.0'):
+		service['command'] = ['--default-authentication-plugin=mysql_native_password']
+	return [service]
 
 def buildTestConfig(params):
 	configs = []

--- a/.drone.star
+++ b/.drone.star
@@ -59,8 +59,7 @@ config = {
 			],
 			'databases': [
 				'mariadb:10.2',
-				'mysql:5.5',
-				'mysql:5.7',
+				'mysql:8.0',
 				'postgres:9.4',
 				'oracle'
 			],
@@ -138,7 +137,7 @@ config = {
 				'apiAll': 'core-apiAll',
 			},
 			'databases': [
-				'mysql:5.7',
+				'mysql:8.0',
 			],
 			'servers': [
 				'daily-master-qa',
@@ -158,7 +157,7 @@ config = {
 				'cliAll': 'core-cliAll',
 			},
 			'databases': [
-				'mysql:5.7',
+				'mysql:8.0',
 			],
 			'servers': [
 				'daily-master-qa',
@@ -178,7 +177,7 @@ config = {
 				'webUIall': 'core-webUI',
 			},
 			'databases': [
-				'mysql:5.7',
+				'mysql:8.0',
 			],
 			'servers': [
 				'daily-master-qa',


### PR DESCRIPTION
1) update the common drone starlark code to be current (from activity app)
2) test with mySQL 8.0, which is the official supported mySQL version.