### PR TITLE
Add docstring to the unlink method in the AvirWrapper

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -253,7 +253,12 @@ class AvirWrapper extends Wrapper {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Objectstore implementations do no use part files, so PermissionsMask wrapper
+	 * cannot delete the infected file. To bypass this, antivirus will ignore
+	 * all wrappers and delete directly on the physical storage.
+	 *
+	 * @param string $path
+	 * @return bool
 	 */
 	public function unlink($path) {
 		$storage = $this->getWrapperStorage();

--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -253,7 +253,7 @@ class AvirWrapper extends Wrapper {
 	}
 
 	/**
-	 * Objectstore implementations do no use part files, so PermissionsMask wrapper
+	 * Objectstore implementations do not use part files, so PermissionsMask wrapper
 	 * cannot delete the infected file. To bypass this, antivirus will ignore
 	 * all wrappers and delete directly on the physical storage.
 	 *


### PR DESCRIPTION
...because the reasoning behind it is not clear.

Related to https://github.com/owncloud/enterprise/issues/4427