### PR TITLE
Wait for icap service before running unit tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -284,6 +284,8 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'wait-for-it dummy-clamav:5555',
+						'wait-for-it -t 600 icap:1344',
+						'sleep 10'
 					]
 				}
 			],


### PR DESCRIPTION
Wait for `icap` service to come live before running the unit tests

fixes https://github.com/owncloud/files_antivirus/issues/414