### PR TITLE
[tests-only] Activity app now requires core 10.7.1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -52,6 +52,9 @@ config = {
 			'extraApps': {
 				'activity': ''
 			},
+			'servers': [
+			    'daily-master-qa',
+			],
 		},
 		'webUI-icap': {
 			'suites': {
@@ -63,6 +66,9 @@ config = {
 			'extraApps': {
 				'activity': ''
 			},
+			'servers': [
+			    'daily-master-qa',
+			],
 			'extraSetup': [
 				{
 					'name': 'configure-app',


### PR DESCRIPTION
Do not test files_antivirus+activity app combination against an "old" 10.7.0 core.

Similar to PR https://github.com/owncloud/files_texteditor/pull/341