### PR TITLE
Prevent from crashing on missing or expired license

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -6,7 +6,7 @@
  * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
  *
  * @copyright 2012 Manuel Deglado manuel.delgado@ucr.ac.cr
- * @copyright 2014-2018 Viktar Dubiniuk
+ * @copyright 2014-2021 Viktar Dubiniuk
  * @license AGPL-3.0
  *
  * This library is free software; you can redistribute it and/or
@@ -24,14 +24,4 @@
  *
  */
 
-$app = new \OCA\Files_Antivirus\AppInfo\Application();
-OCP\Util::connectHook('OC_Filesystem', 'preSetup', $app, 'setupWrapper');
-
-\OC::$server->getActivityManager()->registerExtension(
-	function () {
-		return new \OCA\Files_Antivirus\Activity(
-			\OC::$server->query('L10NFactory'),
-			\OC::$server->getURLGenerator()
-		);
-	}
-);
+(new \OCA\Files_Antivirus\AppInfo\Application())->init();

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@ More information is available in the Anti-Virus documentation.
 	<use-migrations>true</use-migrations>
 	<namespace>Files_Antivirus</namespace>
 	<dependencies>
-		<owncloud min-version="10.5" max-version="10" />
+		<owncloud min-version="10.6" max-version="10" />
 	</dependencies>
 	<settings>
 		<admin>OCA\Files_Antivirus\AdminPanel</admin>

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -164,6 +164,8 @@ class AppConfig {
 	 * @param string $value
 	 *
 	 * @return void
+	 *
+	 * @throws \UnexpectedValueException
 	 */
 	public function setAppValue($key, $value) {
 		$this->validateValue($key, $value);
@@ -175,9 +177,15 @@ class AppConfig {
 	 * @param string $value
 	 *
 	 * @return void
+	 *
+	 * @throws \UnexpectedValueException
 	 */
 	public function validateValue($key, $value) {
-		if ($key === 'av_mode' && $value === 'icap'&& !$this->licenseManager->checkLicenseFor('icap')) {
+		if (
+			$key === 'av_mode'
+			&& $value === 'icap'
+			&& !$this->licenseManager->checkLicenseFor($this->appName, ["disableApp" => false])
+		) {
 			$this->logger->error('No valid license found for icap scanner');
 			throw new \UnexpectedValueException("No valid license found for icap scanner mode");
 		}

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -147,7 +147,14 @@ class AppConfig {
 		if (\array_key_exists($key, $this->defaults)) {
 			$defaultValue = $this->defaults[$key];
 		}
-		return $this->config->getAppValue($this->appName, $key, $defaultValue);
+		$value = $this->config->getAppValue($this->appName, $key, $defaultValue);
+		try {
+			$this->validateValue($key, $value);
+		} catch (\UnexpectedValueException $e) {
+			$this->logger->error('No valid license found for icap scanner, resetting mode to executable');
+			$value = 'executable';
+		}
+		return  $value;
 	}
 
 	/**
@@ -170,11 +177,9 @@ class AppConfig {
 	 * @return void
 	 */
 	public function validateValue($key, $value) {
-		if ($key === 'av_mode' && $value === 'icap') {
-			if (!$this->licenseManager->checkLicenseFor('icap')) {
-				$this->logger->error('No valid license found for icap scanner');
-				throw new \UnexpectedValueException("No valid license found for icap scanner mode");
-			}
+		if ($key === 'av_mode' && $value === 'icap'&& !$this->licenseManager->checkLicenseFor('icap')) {
+			$this->logger->error('No valid license found for icap scanner');
+			throw new \UnexpectedValueException("No valid license found for icap scanner mode");
 		}
 	}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,7 +32,9 @@ class Application extends App {
 			'AppConfig',
 			function ($c) {
 				return new AppConfig(
-					$c->query('CoreConfig')
+					$c->query('CoreConfig'),
+					$c->query('ServerContainer')->getLicenseManager(),
+					$c->query('ServerContainer')->getLogger()
 				);
 			}
 		);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,8 +15,6 @@ namespace OCA\Files_Antivirus\AppInfo;
 
 use OCA\Files_Antivirus\AppConfig;
 use OCA\Files_Antivirus\AvirWrapper;
-use OCA\Files_Antivirus\Controller\RuleController;
-use OCA\Files_Antivirus\Controller\SettingsController;
 use OCA\Files_Antivirus\Cron\Task;
 use OCA\Files_Antivirus\Db\RuleMapper;
 use OCA\Files_Antivirus\Db\FileCollection;
@@ -30,29 +28,6 @@ class Application extends App {
 		parent::__construct('files_antivirus', $urlParams);
 
 		$container = $this->getContainer();
-		$container->registerService(
-			'RuleController',
-			function ($c) {
-				return new RuleController(
-					$c->query('AppName'),
-					$c->query('Request'),
-					$c->query('Logger'),
-					$c->query('L10N'),
-					$c->query('RuleMapper')
-				);
-			}
-		);
-		$container->registerService(
-			'SettingsController',
-			function ($c) {
-				return new SettingsController(
-					$c->query('Request'),
-					$c->query('AppConfig'),
-					$c->query('ScannerFactory'),
-					$c->query('L10N')
-				);
-			}
-		);
 		$container->registerService(
 			'AppConfig',
 			function ($c) {
@@ -135,6 +110,25 @@ class Application extends App {
 			'L10N',
 			function ($c) {
 				return $c->query('ServerContainer')->getL10N($c->query('AppName'));
+			}
+		);
+	}
+
+	/**
+	 * Initial app setup
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', $this, 'setupWrapper');
+		$server = $this->getContainer()->getServer();
+
+		$server->getActivityManager()->registerExtension(
+			function () use ($server) {
+				return new \OCA\Files_Antivirus\Activity(
+					$server->query('L10NFactory'),
+					$server->getURLGenerator()
+				);
 			}
 		);
 	}

--- a/lib/Scanner/ICAPClient.php
+++ b/lib/Scanner/ICAPClient.php
@@ -148,7 +148,7 @@ class ICAPClient {
 		foreach (\preg_split('/\r?\n/', $response) as $line) {
 			if ($responseArray['protocol'] === []) {
 				if (\strpos($line, 'ICAP/') !== 0) {
-					throw new RuntimeException('Unknown ICAP response');
+					throw new RuntimeException("Unknown ICAP response: \"$response\"");
 				}
 
 				$parts = \preg_split('/\ +/', $line, 3);

--- a/lib/ScannerFactory.php
+++ b/lib/ScannerFactory.php
@@ -7,7 +7,7 @@
  *
  * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
  *
- * @copyright Viktar Dubiniuk 2014-2018
+ * @copyright Viktar Dubiniuk 2014-2021
  * @license AGPL-3.0
  */
 
@@ -76,11 +76,6 @@ class ScannerFactory {
 				break;
 			case 'icap':
 				$this->scannerClass = ICAPScanner::class;
-				if (!\OC::$server->getLicenseManager()->checkLicenseFor('icap')) {
-					\OC::$server->getLogger()->error('No valid license found for icap scanner');
-					throw new InitException("No valid license found for icap scanner");
-				}
-
 				break;
 			default:
 				throw new InitException(

--- a/tests/unit/AvirWrapperTest.php
+++ b/tests/unit/AvirWrapperTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2016 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * Copyright (c) 2021 Viktar Dubiniuk <dubiniuk@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -57,7 +57,11 @@ class AvirWrapperTest extends TestBase {
 		}
 
 		$this->scannerFactory = new Mock\ScannerFactory(
-			new Mock\Config($this->container->query('CoreConfig')),
+			new Mock\Config(
+				$this->container->query('CoreConfig'),
+				$this->container->query('ServerContainer')->getLicenseManager(),
+				$this->container->query('ServerContainer')->getLogger()
+			),
 			$this->container->query('Logger'),
 			$this->container->query(IL10N::class)
 		);

--- a/tests/unit/ChunkUploadTest.php
+++ b/tests/unit/ChunkUploadTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright (c) 2017 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * Copyright (c) 2021 Viktar Dubiniuk <dubiniuk@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -30,16 +30,20 @@ class ChunkUploadTest extends TestBase {
 		\OC_User::clearBackends();
 		\OC_User::useBackend(new Dummy());
 	}
-	
+
 	public function setUp(): void {
 		parent::setUp();
 		if (!\OC::$server->getUserManager()->get(self::UID)) {
 			\OC::$server->getUserManager()->createUser(self::UID, self::PWD);
 		}
-		
+
 		$this->scannerFactory = $this->getMockBuilder(ScannerFactory::class)
 			->setConstructorArgs([
-				new Mock\Config($this->container->query('CoreConfig')),
+				new Mock\Config(
+					$this->container->query('CoreConfig'),
+					$this->container->query('ServerContainer')->getLicenseManager(),
+					$this->container->query('ServerContainer')->getLogger()
+				),
 				$this->container->query('Logger'),
 				$this->container->query(IL10N::class)
 			])
@@ -73,7 +77,7 @@ class ChunkUploadTest extends TestBase {
 		@\fwrite($fd, 'abcdead');
 		@\fclose($fd);
 	}
-	
+
 	public function wrapperCallback($mountPoint, $storage) {
 		/**
 		 * @var Storage $storage

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright (c) 2016 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * Copyright (c) 2021 Viktar Dubiniuk <dubiniuk@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -56,13 +56,15 @@ class SettingsControllerTest extends TestBase {
 		$this->config->expects(self::atLeast(1))
 			->method('setter')
 			->withConsecutive(
-				['av_mode', ['executable']],
 				['av_cmd_options', ['--fdpass']],
-				['av_path', ['/usr/bin/clamav']]
+				['av_path', ['/usr/bin/clamav']],
+				['av_infected_action', ['delete']],
+				['av_stream_max_length', [100]],
+				['av_max_file_size', [800]],
+				['av_mode', ['executable']]
 			);
 
 		$settings = new SettingsController($this->request, $this->config, $this->scannerFactory, $this->l10n);
-
 		$settings->save(
 			'executable',
 			null,
@@ -80,8 +82,11 @@ class SettingsControllerTest extends TestBase {
 		$this->config->expects(self::atLeast(1))
 			->method('setter')
 			->withConsecutive(
-				['av_mode', ['socket']],
-				['av_socket', ['/var/run/clamd.sock']]
+				['av_socket', ['/var/run/clamd.sock']],
+				['av_infected_action', ['delete']],
+				['av_stream_max_length', [100]],
+				['av_max_file_size', [800]],
+				['av_mode', ['socket']]
 			);
 
 		$settings = new SettingsController($this->request, $this->config, $this->scannerFactory, $this->l10n);
@@ -107,13 +112,15 @@ class SettingsControllerTest extends TestBase {
 		$this->config->expects(self::atLeast(1))
 			->method('setter')
 			->withConsecutive(
-				['av_mode', ['daemon']],
 				['av_port', ['90']],
-				['av_host', [$avirHost]]
+				['av_host', [$avirHost]],
+				['av_infected_action', ['delete']],
+				['av_stream_max_length', [100]],
+				['av_max_file_size', [800]],
+				['av_mode', ['daemon']]
 			);
 
 		$settings = new SettingsController($this->request, $this->config, $this->scannerFactory, $this->l10n);
-
 		$settings->save(
 			'daemon',
 			null,

--- a/tests/unit/Cron/TaskTest.php
+++ b/tests/unit/Cron/TaskTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2015 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * Copyright (c) 2021 Viktar Dubiniuk <dubiniuk@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -35,7 +35,7 @@ class TaskTest extends TestBase {
 			$this->container->query(IL10N::class)
 		);
 	}
-	
+
 	public function testRun() {
 		$cronMock = new Task(
 			$this->container->getServer()->getUserSession(),
@@ -56,7 +56,11 @@ class TaskTest extends TestBase {
 
 	public function testGetFilesForScan() {
 		$scannerFactory = new ScannerMock(
-			new ConfigMock($this->container->query('CoreConfig')),
+			new ConfigMock(
+				$this->container->query('CoreConfig'),
+				$this->container->query('ServerContainer')->getLicenseManager(),
+				$this->container->query('ServerContainer')->getLogger()
+			),
 			$this->container->query('Logger'),
 			$this->container->query(IL10N::class)
 		);


### PR DESCRIPTION
0. Prerequisite: have **NO** valid license
1. Set mode to `ICAP`

### Expected for Web UI
UI Feedback that it's not possible to set `ICAP` as a mode due to an invalid license

### Expected for CLI
Value is saved (there is no way to control that) but is not used

### Actual behavior (both CLI/Web UI)
OC is constantly crashing until a valid license is provided, the mode is changed to anything else but `ICAP`  or files_antivirus is disabled. All these actions are possible via CLI only as Web UI is not working any more.

## Changed in this PR
- No hard crash any more
- switching mode to `icap` via Web UI is prevented if the license is invalid
- in case the license is expired or mode was set to `icap` via CLI the mode value is overloaded with `executable` at the runtime.
The message 'No valid license found for icap scanner, resetting mode to executable' is written to log file accordingly.
