### PR TITLE
Do not depend on the sockets PHP extension

### DIFF
--- a/lib/Scanner/ICAPClient.php
+++ b/lib/Scanner/ICAPClient.php
@@ -16,13 +16,13 @@ class ICAPClient {
 	}
 
 	private function connect(): void {
+		// Shut stupid uncontrolled messaging up - we handle errors on our own
 		$this->writeHandle = @\stream_socket_client(
 			"tcp://{$this->host}:{$this->port}",
 			$errorCode,
 			$errorMessage,
 			5
 		);
-
 		if (!$this->writeHandle) {
 			throw new InitException(
 				"Cannot connect to \"tcp://{$this->host}:{$this->port}\": $errorMessage (code $errorCode)"
@@ -31,6 +31,7 @@ class ICAPClient {
 	}
 
 	private function disconnect(): void {
+		// Due to suppressed output it could be a point of interest for debugging. Someday. Maybe.
 		@\fclose($this->writeHandle);
 	}
 
@@ -117,6 +118,7 @@ class ICAPClient {
 
 	private function send(string $request): string {
 		$this->connect();
+		// Shut stupid uncontrolled messaging up - we handle errors on our own
 		if (@\fwrite($this->writeHandle, $request) === false) {
 			throw new InitException(
 				"Writing to \"{$this->host}:{$this->port}}\" failed"

--- a/lib/Scanner/ICAPClient.php
+++ b/lib/Scanner/ICAPClient.php
@@ -25,13 +25,7 @@ class ICAPClient {
 
 		if (!$this->writeHandle) {
 			throw new InitException(
-				\sprintf(
-					'Cannot connect to "tcp://%s:%s": %s (code %d)',
-					$this->host,
-					$this->port,
-					$errorMessage,
-					$errorCode
-				)
+				"Cannot connect to \"tcp://{$this->host}:{$this->port}\": $errorMessage (code $errorCode)"
 			);
 		}
 	}
@@ -125,7 +119,7 @@ class ICAPClient {
 		$this->connect();
 		if (@\fwrite($this->writeHandle, $request) === false) {
 			throw new InitException(
-				\sprintf('Writing to "%s:%s" failed', $this->host, $this->port)
+				"Writing to \"{$this->host}:{$this->port}}\" failed"
 			);
 		}
 


### PR DESCRIPTION
This PR makes no need to have sockets PHP extension installed and enabled. 
In most systems this extension is not  enabled out of a box. In this case files_antivirus is silently crashing after  'icap' mode is chosen.
Closes #427 

