### PR TITLE
Check content before create for public upload case

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -218,7 +218,11 @@ class AppConfig {
 	 */
 	protected function getter($key) {
 		if (\array_key_exists($key, $this->defaults)) {
-			return $this->getAppValue($key);
+			$value = $this->getAppValue($key);
+			if ($key === 'av_max_file_size') {
+				return (int) $value;
+			}
+			return $value;
 		} else {
 			throw new \BadFunctionCallException($key . ' is not a valid key');
 		}

--- a/lib/IScannable.php
+++ b/lib/IScannable.php
@@ -17,6 +17,8 @@ interface IScannable {
 	/**
 	 * Return av_chunk_size bytes of something
 	 * or false when there is no more bytes left
+	 *
+	 * @return string|false
 	 */
 	public function fread();
 }

--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * ownCloud - files_antivirus
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Viktar Dubiniuk 2021
+ * @license AGPL-3.0
+ */
+
+namespace OCA\Files_Antivirus;
+
+class Resource implements IScannable {
+	protected $resource;
+	protected $chunkSize;
+
+	public function __construct($resource, $chunkSize) {
+		$this->resource = $resource;
+		$this->chunkSize = $chunkSize;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function fread() {
+		if (\feof($this->resource)) {
+			return false;
+		}
+		return \fread($this->resource, $this->chunkSize);
+	}
+}

--- a/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusFileSize.feature
@@ -103,10 +103,8 @@ Feature: Antivirus file size
       | --   | files_antivirus | PUT    | Infected file deleted |
     And as "Alice" file "/FOLDER/eicar.com" should not exist
 
-  @skip @issue-334
   Scenario: Files smaller than the upload threshold are checked for viruses when uploaded via new public upload
-    Given the administrator has enabled DAV tech_preview
-    And as user "Alice"
+    Given as user "Alice"
     And user "Alice" has created a public link share of folder "FOLDER" with change permissions
     And parameter "av_max_file_size" of app "files_antivirus" has been set to "100"
     When the public uploads file "eicar.com" from the antivirus test data folder using the new WebDAV API

--- a/tests/acceptance/features/apiAntivirus/antivirusMain.feature
+++ b/tests/acceptance/features/apiAntivirus/antivirusMain.feature
@@ -121,10 +121,8 @@ Feature: Antivirus basic
       | eicar_com.zip   |
       | eicarcom2.zip   |
 
-  @skip @issue-334
   Scenario Outline: A small file with a virus cannot be uploaded via new public upload
-    Given the administrator has enabled DAV tech_preview
-    And as user "Alice"
+    Given as user "Alice"
     And user "Alice" has created a public link share of folder "FOLDER" with change permissions
     When the public uploads file "<virus-file-name>" from the antivirus test data folder using the new WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/unit/Scanner/IcapScannerTest.php
+++ b/tests/unit/Scanner/IcapScannerTest.php
@@ -27,6 +27,7 @@ class IcapScannerTest extends TestCase {
 				'getAvPort',
 				'getAvRequestService',
 				'getAvResponseHeader',
+				'getAvMaxFileSize',
 			])
 			->getMock();
 
@@ -38,6 +39,7 @@ class IcapScannerTest extends TestCase {
 		$config->method('getAvPort')->willReturn(1344);
 		$config->method('getAvRequestService')->willReturn('avscan');
 		$config->method('getAvResponseHeader')->willReturn('X-Infection-Found');
+		$config->method('getAvMaxFileSize')->willReturn(-1);
 
 		$this->scanner = new ICAPScanner($config, $logger, $l10n);
 	}


### PR DESCRIPTION
In case of public upload we need to scan the content before the file is created. 
Otherwise after the virus is detected we end up with an empty locked file.

Fixes #334 