### PR TITLE
Do not scan an empty content in ICAP mode

### DIFF
--- a/lib/Scanner/ICAPScanner.php
+++ b/lib/Scanner/ICAPScanner.php
@@ -20,7 +20,7 @@ class ICAPScanner {
 		$this->l10n = $l10n;
 	}
 
-	private $data;
+	private $data = '';
 	private $host;
 	private $port;
 	private $reqService;


### PR DESCRIPTION
Fixes #438 

https://github.com/owncloud/files_antivirus/blob/e65a2a3971ed0f747ac7f8f23f4ebb8dcbad520d/lib/Scanner/ICAPScanner.php#L37-L39

`$this->data` is `null` for the empty content so the whole condition is `false`