### PR TITLE
Move executable options into config.php

### DIFF
--- a/appinfo/Migrations/Version20210413110050.php
+++ b/appinfo/Migrations/Version20210413110050.php
@@ -19,14 +19,12 @@ use OCP\Migration\ISqlMigration;
 /**
  * Cleans table before adding etag field
  */
-class Version20210413110050 implements ISqlMigration
-{
+class Version20210413110050 implements ISqlMigration {
 	/**
 	 * @param IDBConnection $connection
 	 * @return void
 	 */
-	public function sql(IDBConnection $conn)
-	{
+	public function sql(IDBConnection $conn) {
 		$conf = \OC::$server->getConfig();
 		$query = 'SELECT configkey, configvalue FROM `*PREFIX*appconfig` WHERE `appid` = `files_antivirus` and (`configkey` = `av_path` or `configkey` = `av_cmd_options`)';
 		$result = $conn->executeQuery($query);

--- a/appinfo/Migrations/Version20210413110050.php
+++ b/appinfo/Migrations/Version20210413110050.php
@@ -26,7 +26,7 @@ class Version20210413110050 implements ISqlMigration {
 	 */
 	public function sql(IDBConnection $conn) {
 		$conf = \OC::$server->getConfig();
-		$query = 'SELECT configkey, configvalue FROM `*PREFIX*appconfig` WHERE `appid` = `files_antivirus` and (`configkey` = `av_path` or `configkey` = `av_cmd_options`)';
+		$query = 'SELECT `configkey`, `configvalue` FROM `*PREFIX*appconfig` WHERE `appid` = \'files_antivirus\' AND (`configkey` = \'av_path\' OR `configkey` = \'av_cmd_options\')';
 		$result = $conn->executeQuery($query);
 		while ($row = $result->fetch()) {
 			try {
@@ -38,7 +38,7 @@ class Version20210413110050 implements ISqlMigration {
 		}
 		$result->closeCursor();
 
-		$query = 'DELETE FROM `*PREFIX*appconfig` WHERE `appid` = `files_antivirus` and (`configkey` = `av_path` or `configkey` = `av_cmd_options`)';
+		$query = 'DELETE FROM `*PREFIX*appconfig` WHERE `appid` = \'files_antivirus\' AND (`configkey` = \'av_path\' OR `configkey` = \'av_cmd_options\')';
 		$result = $conn->executeQuery($query);
 		$result->closeCursor();
 	}

--- a/appinfo/Migrations/Version20210413110050.php
+++ b/appinfo/Migrations/Version20210413110050.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Files_antivirus
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author David Christofas <dchristofas@owncloud.com>
+ *
+ * @copyright David Christofas 2021
+ * @license AGPL-3.0
+ */
+
+namespace OCA\Files_Antivirus\Migrations;
+
+use OCP\IDBConnection;
+use OCP\Migration\ISqlMigration;
+
+/**
+ * Cleans table before adding etag field
+ */
+class Version20210413110050 implements ISqlMigration
+{
+	/**
+	 * @param IDBConnection $connection
+	 * @return void
+	 */
+	public function sql(IDBConnection $conn)
+	{
+		$conf = \OC::$server->getConfig();
+		$query = 'SELECT configkey, configvalue FROM `*PREFIX*appconfig` WHERE `appid` = `files_antivirus` and (`configkey` = `av_path` or `configkey` = `av_cmd_options`)';
+		$result = $conn->executeQuery($query);
+		while ($row = $result->fetch()) {
+			try {
+				$conf->setSystemValue('files_antivirus.' . $row['configkey'], $row['configvalue']);
+			} catch (\Exception $e) {
+				echo 'Migration failed: ', $e->getMessage(), '\n';
+				return;
+			}
+		}
+		$result->closeCursor();
+
+		$query = 'DELETE FROM `*PREFIX*appconfig` WHERE `appid` = `files_antivirus` and (`configkey` = `av_path` or `configkey` = `av_cmd_options`)';
+		$result = $conn->executeQuery($query);
+		$result->closeCursor();
+	}
+}

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -147,6 +147,9 @@ class AppConfig {
 		if (\array_key_exists($key, $this->defaults)) {
 			$defaultValue = $this->defaults[$key];
 		}
+		if ($key === 'av_path' || $key === 'av_cmd_options') {
+		    return $this->config->getSystemValue($this->appName . "." . $key, $defaultValue);
+		}
 		$value = $this->config->getAppValue($this->appName, $key, $defaultValue);
 		try {
 			$this->validateValue($key, $value);
@@ -168,6 +171,9 @@ class AppConfig {
 	 * @throws \UnexpectedValueException
 	 */
 	public function setAppValue($key, $value) {
+		if ($key === 'av_path' || $key === 'av_cmd_options') {
+			return;
+		}
 		$this->validateValue($key, $value);
 		$this->config->setAppValue($this->appName, $key, $value);
 	}

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -148,7 +148,7 @@ class AppConfig {
 			$defaultValue = $this->defaults[$key];
 		}
 		if ($key === 'av_path' || $key === 'av_cmd_options') {
-		    return $this->config->getSystemValue($this->appName . "." . $key, $defaultValue);
+			return $this->config->getSystemValue($this->appName . "." . $key, $defaultValue);
 		}
 		$value = $this->config->getAppValue($this->appName, $key, $defaultValue);
 		try {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -73,8 +73,6 @@ class SettingsController extends Controller {
 	 * @param string $avSocket - path to socket (Socket mode)
 	 * @param string $avHost - antivirus url
 	 * @param int $avPort - port
-	 * @param string $avCmdOptions - extra command line options
-	 * @param string $avPath - path to antivirus executable (Executable mode)
 	 * @param string $avInfectedAction - action performed on infected files
 	 * @param int $avStreamMaxLength - reopen socket after bytes
 	 * @param int $avMaxFileSize - file size limit
@@ -84,14 +82,11 @@ class SettingsController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function save($avMode, $avSocket, $avHost, $avPort,
-		$avCmdOptions, $avPath, $avInfectedAction, $avStreamMaxLength,
+		$avInfectedAction, $avStreamMaxLength,
 						 $avMaxFileSize, $avRequestService, $avResponseHeader
 	) {
 		try {
-			if ($avMode === 'executable') {
-				$this->settings->setAvCmdOptions($avCmdOptions);
-				$this->settings->setAvPath($avPath);
-			} elseif ($avMode === 'daemon') {
+			if ($avMode === 'daemon') {
 				$this->settings->setAvPort($avPort);
 				$this->settings->setAvHost($avHost);
 			} elseif ($avMode === 'socket') {

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -40,12 +40,14 @@ script('files_antivirus', 'settings');
 				<input type="text" id="av_response_header" name="avResponseHeader" value="<?php p($_['avResponseHeader']); ?>" />
 			</p>
 			<p class="av_path">
-				<label for="av_path"><?php p($l->t('Path to clamscan'));?></label>
-				<input type="text" id="av_path" name="avPath" value="<?php p($_['avPath']); ?>" title="<?php p($l->t('Path to clamscan executable')); ?>" />
+				<label for="av_path"><?php p($l->t('Path to clamscan')); ?></label>
+				<span id="av_path"><?php p($_['avPath']); ?></span>
+				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html">system configuration ↗</a>.</em>
 			</p>
 			<p class="av_path">
-				<label for="av_cmd_options"><?php p($l->t('Extra command line options (comma-separated)'));?></label>
-				<input type="text" id="av_cmd_options" name="avCmdOptions" value="<?php p($_['avCmdOptions']); ?>" />
+				<label for="av_cmd_options"><?php p($l->t('Extra command line options (comma-separated)')); ?></label>
+				<span id="av_cmd_options"><?php p($_['avCmdOptions']); ?></span>
+				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html">system configuration ↗</a>.</em>
 			</p>
 			<p class="av_stream_max_length">
 				<label for="av_stream_max_length">

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -56,8 +56,6 @@ class SettingsControllerTest extends TestBase {
 		$this->config->expects(self::atLeast(1))
 			->method('setter')
 			->withConsecutive(
-				['av_cmd_options', ['--fdpass']],
-				['av_path', ['/usr/bin/clamav']],
 				['av_infected_action', ['delete']],
 				['av_stream_max_length', [100]],
 				['av_max_file_size', [800]],
@@ -70,8 +68,6 @@ class SettingsControllerTest extends TestBase {
 			null,
 			null,
 			null,
-			'--fdpass',
-			'/usr/bin/clamav',
 			'delete',
 			100,
 			800, '', ''
@@ -94,8 +90,6 @@ class SettingsControllerTest extends TestBase {
 		$settings->save(
 			'socket',
 			'/var/run/clamd.sock',
-			null,
-			null,
 			null,
 			null,
 			'delete',
@@ -126,8 +120,6 @@ class SettingsControllerTest extends TestBase {
 			null,
 			$avirHost,
 			'90',
-			null,
-			null,
 			'delete',
 			100,
 			800, '', ''


### PR DESCRIPTION
## Documentation relevant
new `config.sample.php` options are
`files_antivitus.av_path`
`files_antivitus.av_cmd_options`

- [x] dependant core PR  https://github.com/owncloud/core/pull/38753