### PR TITLE
Scan public upload on update

### DIFF
--- a/tests/unit/RequestHelperTest.php
+++ b/tests/unit/RequestHelperTest.php
@@ -13,7 +13,10 @@ use OCA\DAV\Upload\FutureFile;
 use OCA\Files_Antivirus\AppInfo\Application;
 use OCA\Files_Antivirus\Dav\AntivirusPlugin;
 use OCA\Files_Antivirus\RequestHelper;
-use \OCP\IRequest;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use Sabre\DAV\Tree;
 
 class RequestHelperTest extends TestBase {
@@ -112,7 +115,13 @@ class RequestHelperTest extends TestBase {
 		$server = $this->createMock(\Sabre\DAV\Server::class);
 		$server->tree = $tree;
 
-		$plugin = new AntivirusPlugin(new Application());
+		$user =$this->createMock(IUser::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($user);
+
+		$logger = $this->createMock(ILogger::class);
+
+		$plugin = new AntivirusPlugin(new Application(), $userSession, $logger);
 		$plugin->initialize($server);
 		$plugin->beforeMove('/something/.file', $davPath);
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/files_antivirus/issues/334 completely

Now when a new content of the file in the public upload folder is infected we just keep the old content.
The behavior spotted in https://github.com/owncloud/files_antivirus/issues/334#issuecomment-848609138 (a stray DB entry with a missing file on the FS) is no longer reproducible.

```
> URL="http://localhost/~deo/oc-tmp/remote.php/dav/public-files/jfsT7ujGSK8JMNn/somenewfile.txt" 
deo@jah-mobile:~> curl $URL -X PUT --data "Hello World"                                        
deo@jah-mobile:~> curl $URL -T ~/public_html/_craft/testfiles/eicar.txt
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>OCP\Files\FileContentNotAllowedException</s:exception>
  <s:message>Virus Type=0; Resolution=2; Threat=Win.Test.EICAR_HDB-1; is detected in the file. Upload cannot be completed.</s:message>
</d:error>
```