### PR TITLE
Remove unneeded skip trashbin hack

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -177,19 +177,7 @@ class AvirWrapper extends Wrapper {
 			);
 
 			if ($shouldDelete) {
-				//prevent from going to trashbin
-				if (App::isEnabled('files_trashbin')) {
-					\OCA\Files_Trashbin\Storage::preRenameHook(
-						[
-							Filesystem::signal_param_oldpath => '',
-							Filesystem::signal_param_newpath => ''
-						]
-					);
-				}
 				$this->unlink($path);
-				if (App::isEnabled('files_trashbin')) {
-					\OCA\Files_Trashbin\Storage::postRenameHook([]);
-				}
 			}
 
 			throw new FileContentNotAllowedException(


### PR DESCRIPTION
According to my tests https://github.com/owncloud/files_antivirus/issues/68 is not reproducible any more even if trashbin bypass code is removed.
Most likely https://github.com/owncloud/files_antivirus/pull/373 fixed it.

Closes https://github.com/owncloud/files_antivirus/issues/199

Tested by uploading an infected file and checking 'Deleted files' after that.
