### PR TITLE
[tests-only] [full-ci] Bump to phpunit9 in acceptance tests

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -17,6 +17,6 @@
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^6.5",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.5"
     }
 }


### PR DESCRIPTION
`phpunit` was updated to major version 9 in core PR https://github.com/owncloud/core/pull/39290

Also bump to phpunit9 in the acceptance tests.