### PR TITLE
[tests-only] [full-ci] Do not run dbConversion core tests in app CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -228,7 +228,7 @@ config = {
             "runAllSuites": True,
             "numberOfParts": 3,
             "emailNeeded": True,
-            "filterTags": "~@skip&&~@app-required",
+            "filterTags": "~@skip&&~@app-required&&~@dbConversion",
         },
         "core-webui-acceptance": {
             "suites": {


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/files_antivirus/2290/63/15
`cliDbConversion/dbConversion.feature:30` failed.
That scenario is designed to start with sqlite DB and convert to mysql. It should only run in a special core CI pipeline.