### PR TITLE
[tests-only][full-ci]Tidy up the phpunit xml file for files_antivirus app

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,25 +5,22 @@
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
-		 timeoutForLargeTests="900"
->
-	<testsuites>
-		<testsuite name='unit'>
-			<directory suffix='Test.php'>./tests/unit</directory>
-		</testsuite>
-	</testsuites>
-	<!-- filters for code coverage -->
-	<filter>
-		<whitelist>
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">./l10n</directory>
-				<directory suffix=".php">./tests</directory>
-			</exclude>
-		</whitelist>
-	</filter>
-	<logging>
-		<!-- and this is where your report will be written -->
-		<log type="coverage-clover" target="./tests/output/clover.xml"/>
-	</logging>
+		 timeoutForLargeTests="900">
+  <testsuites>
+   <testsuite name='unit'>
+  	 <directory suffix='Test.php'>./tests/unit</directory>
+   </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+   <directory suffix=".php">.</directory>
+    </include>
+   <exclude>
+     <directory suffix=".php">./l10n</directory>
+     <directory suffix=".php">./tests</directory>
+   </exclude>
+    <report>
+     <clover outputFile="./tests/output/clover.xml"/>
+    </report>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
This PR moves unit tests into tests/unit folder. And also tidy up the `phpunit.xml` to make standard format for all oc-apps as much as possible.

- Part of https://github.com/owncloud/impersonate/issues/198