### PR TITLE
[tests-only] [full-ci] Do not test with S3 and core latest 10.10

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -157,7 +157,6 @@ config = {
             },
             "servers": [
                 "daily-master-qa",
-                "latest",
             ],
             "databases": [
                 "mariadb:10.2",
@@ -189,7 +188,6 @@ config = {
             },
             "servers": [
                 "daily-master-qa",
-                "latest",
             ],
             "databases": [
                 "mariadb:10.2",


### PR DESCRIPTION
## Description
`files_primary_s3` `master` now has the code for the Guzzle7 major version change. So we know that it does not work with core "latest" 10.10. So do not test that combination.

## Related Issue
Part of https://github.com/owncloud/core/issues/39387

## How Has This Been Tested?
CI

