### PR TITLE
[tests-only] Upgrading bamarni/composer-bin-plugin (v1.5.0 => 1.6.0)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,25 +9,26 @@
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "v1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "49934ffea764864788334c1485fbb08a4b852031"
+                "reference": "80b2f1ca19ff81e9aea495e7cf70443e70d12048"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/49934ffea764864788334c1485fbb08a4b852031",
-                "reference": "49934ffea764864788334c1485fbb08a4b852031",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/80b2f1ca19ff81e9aea495e7cf70443e70d12048",
+                "reference": "80b2f1ca19ff81e9aea495e7cf70443e70d12048",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": "^5.5.9 || ^7.0 || ^8.0"
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "^1.0 || ^2.0",
-                "symfony/console": "^2.5 || ^3.0 || ^4.0"
+                "composer/composer": "^2.0",
+                "phpstan/extension-installer": "^1.1",
+                "symfony/console": "^5.4.7 || ^6.0.7"
             },
             "type": "composer-plugin",
             "extra": {
@@ -53,9 +54,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/v1.5.0"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.6.0"
             },
-            "time": "2022-02-22T21:01:25+00:00"
+            "time": "2022-07-06T22:16:05+00:00"
         }
     ],
     "aliases": [],
@@ -68,5 +69,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
This is a development tool that manages the tool dependencies in `vendor-bin`

dependabot found a lot of these in the app repos and made PRs for them, which I merged today. But it did not make a PR here.