### PR TITLE
fix #496 and #455

### DIFF
--- a/templates/settings.php
+++ b/templates/settings.php
@@ -12,10 +12,10 @@ script('files_antivirus', 'settings');
 				<label for="av_mode"><?php p($l->t('Mode'));?></label>
 				<select id="av_mode" name="avMode">
 					<?php print_unescaped(html_select_options([
-						'executable' => $l->t('Executable'),
-						'daemon' => $l->t('Daemon'),
-						'socket' => $l->t('Daemon (Socket)'),
-						'icap' => $l->t('Daemon (ICAP)'),
+						'executable' => $l->t('ClamAV Executable'),
+						'daemon' => $l->t('ClamAV Daemon'),
+						'socket' => $l->t('ClamAV Daemon (Socket)'),
+						'icap' => $l->t('ClamAV Daemon (ICAP)'),
 					], $_['avMode'])) ?>
 				</select>
 			</p>
@@ -42,12 +42,12 @@ script('files_antivirus', 'settings');
 			<p class="av_path">
 				<label for="av_path"><?php p($l->t('Path to clamscan')); ?></label>
 				<span id="av_path"><?php p($_['avPath']); ?></span>
-				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html">system configuration ↗</a>.</em>
+				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_apps_sample_php_parameters.html">system configuration ↗</a>.</em>
 			</p>
 			<p class="av_path">
 				<label for="av_cmd_options"><?php p($l->t('Extra command line options (comma-separated)')); ?></label>
 				<span id="av_cmd_options"><?php p($_['avCmdOptions']); ?></span>
-				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html">system configuration ↗</a>.</em>
+				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_apps_sample_php_parameters.html">system configuration ↗</a>.</em>
 			</p>
 			<p class="av_stream_max_length">
 				<label for="av_stream_max_length">


### PR DESCRIPTION
This changes translatable strings. Better skip with this release to not breaks all languages.