### PR TITLE
fix issues 496 and 455

### DIFF
--- a/templates/settings.php
+++ b/templates/settings.php
@@ -12,10 +12,10 @@ script('files_antivirus', 'settings');
 				<label for="av_mode"><?php p($l->t('Mode'));?></label>
 				<select id="av_mode" name="avMode">
 					<?php print_unescaped(html_select_options([
-						'executable' => $l->t('Executable'),
-						'daemon' => $l->t('Daemon'),
-						'socket' => $l->t('Daemon (Socket)'),
-						'icap' => $l->t('Daemon (ICAP)'),
+						'executable' => 'ClamAV ' . $l->t('Executable'),
+						'daemon' => 'ClamAV ' . $l->t('Daemon'),
+						'socket' => 'ClamAV ' . $l->t('Daemon (Socket)'),
+						'icap' => 'ClamAV ' . $l->t('Daemon (ICAP)'),
 						'fortinet' => $l->t('Fortinet (ICAP)'),
 						'mawgw' => $l->t('McAfee Webgateway 10.x and higher (ICAP)'),
 					], $_['avMode'])) ?>
@@ -60,12 +60,12 @@ script('files_antivirus', 'settings');
 			<p class="av_path">
 				<label for="av_path"><?php p($l->t('Path to clamscan')); ?></label>
 				<span id="av_path"><?php p($_['avPath']); ?></span>
-				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html">system configuration ↗</a>.</em>
+				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_apps_sample_php_parameters.html">system configuration ↗</a>.</em>
 			</p>
 			<p class="av_path">
 				<label for="av_cmd_options"><?php p($l->t('Extra command line options (comma-separated)')); ?></label>
 				<span id="av_cmd_options"><?php p($_['avCmdOptions']); ?></span>
-				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_sample_php_parameters.html">system configuration ↗</a>.</em>
+				<em>You can change this value in the <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/admin_manual/configuration/server/config_apps_sample_php_parameters.html">system configuration ↗</a>.</em>
 			</p>
 			<p class="av_stream_max_length">
 				<label for="av_stream_max_length">


### PR DESCRIPTION
This is an alternative to PR #497 - by hardcoding the "ClamAV" text, we don't have to change any translation strings. And anyway, I don't think that "ClamAV" is text that should be translated.