### PR TITLE
[tests-only] Check PHP code with 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -50,11 +50,19 @@ config = {
         "master",
     ],
     "appInstallCommandPhp": "make",
-    "codestyle": True,
+    "codestyle": {
+        "multiple": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "phpunit": {
         "allDatabases": {
             "phpVersions": [
                 DEFAULT_PHP_VERSION,
+                "7.3",
             ],
         },
     },


### PR DESCRIPTION
oC10 core up to 10.11 supports PHP 7.3. For the time being, when we release core apps, we want to know that the PHP code works OK with PHP 7.3. So run code-style in CI with PHP 7.3