### PR TITLE
Fix enterprise check for ICAP

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -189,7 +189,7 @@ class AppConfig {
 	public function validateValue($key, $value) {
 		if (
 			$key === 'av_mode'
-			&& $value === 'icap'
+			&& ($value === 'icap'|| $value === 'fortinet' || $value === 'mawgw')
 			&& !$this->licenseManager->checkLicenseFor($this->appName, ["disableApp" => false])
 		) {
 			$this->logger->error('No valid license found for icap scanner');


### PR DESCRIPTION
## Description
Fix enterprise check for ICAP

## Related Issue
- https://github.com/owncloud/files_antivirus/issues/530

## Motivation and Context

In case of no enterprise license present on system, when one tried to save configuration settings using Fortinet (ICAP) or McAfee Webgateway / Skyhigh Secure Web Gateway (ICAP), the configuration could be saved, which is wrong as ICAP is an enterprise-only feature.

## How Has This Been Tested?
Manually. Having no enterprise license and try to save configuration settings when using Fortinet (ICAP) or McAfee Webgateway / Skyhigh Secure Web Gateway (ICAP):

- before this PR: configuration could be saved --> wrong
- after this PR: an error `No valid license found for icap scanner mode` is returned --> correct 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item