### PR TITLE
fix: don't use `Preview` with McAffee - this will result in a `100` r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - 2022-xx-xx
 
--
+### Fixed
+
+- [#502](https://github.com/owncloud/files_antivirus/issues/502) - McAfee Webgateway causes a 60 seconds delay on each upload
+
 
 ## [1.2.1] - 2022-11-21
 

--- a/lib/L10n.php
+++ b/lib/L10n.php
@@ -5,7 +5,7 @@ namespace OCA\Files_Antivirus;
 use OCP\IL10N;
 
 class L10n {
-	public static function getEnduserNotification(IL10N $n) {
-		return $n->t('Either the ownCloud antivirus app is misconfigured or the external antivirus service is not accessible. Please reach out to your system administrator!');
+	public static function getEnduserNotification(IL10N $n): string {
+		return (string)$n->t('Either the ownCloud antivirus app is misconfigured or the external antivirus service is not accessible. Please reach out to your system administrator!');
 	}
 }

--- a/lib/Scanner/ICAPClient.php
+++ b/lib/Scanner/ICAPClient.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace OCA\Files_Antivirus\Scanner;
+use JsonException;
 use RuntimeException;
 
 class ICAPClient {
@@ -67,22 +68,13 @@ class ICAPClient {
 			switch ($type) {
 				case 'req-hdr':
 				case 'res-hdr':
-					# Temp fix, until https://github.com/owncloud/files_antivirus/pull/500
-					if (\array_key_exists('Preview', $headers)) {
-						$encapsulated[$type] = \strlen($data);          # McAfee Webgateway
-					} else {
-						$encapsulated[$type] = \strlen($bodyData);      # ClamAV and Fortinet
-					}
+					$encapsulated[$type] = \strlen($bodyData);
 					$bodyData .= $data;
 					break;
 
 				case 'req-body':
 				case 'res-body':
-					if (\array_key_exists('Preview', $headers)) {
-						$encapsulated[$type] = \strlen($data);          # McAfee Webgateway
-					} else {
-						$encapsulated[$type] = \strlen($bodyData);      # ClamAV and Fortinet
-					}
+					$encapsulated[$type] = \strlen($bodyData);
 					$bodyData .= \dechex(\strlen($data)) . "\r\n";
 					$bodyData .= $data;
 					$bodyData .= "\r\n";
@@ -142,6 +134,7 @@ class ICAPClient {
 
 	/**
 	 * @throws InitException
+	 * @throws JsonException
 	 */
 	private function send(string $request): array {
 		$this->connect();

--- a/lib/Scanner/ICAPResponseAnalyser.php
+++ b/lib/Scanner/ICAPResponseAnalyser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OCA\Files_Antivirus\Scanner;
+
+use OCA\Files_Antivirus\Status;
+
+class ICAPResponseAnalyser {
+	/** @var string */
+	private $virusHeader;
+
+	public function __construct(string $virusHeader) {
+		$this->virusHeader = $virusHeader;
+	}
+
+	public function analyseResponse(array $response): ?array {
+		$code = $response['protocol']['code'] ?? 500;
+		if ($code === 100 || $code === 200 || $code === 204) {
+			// c-icap/clamav reports this header - McAfee 11 reports the virus name in `res-hdr`
+			$virus = $response['headers'][$this->virusHeader] ?? $response['body']['res-hdr'][$this->virusHeader] ?? false;
+			if ($virus) {
+				return [Status::SCANRESULT_INFECTED, $virus];
+			}
+
+			// kaspersky(pre-2020 product editions) and McAfee handling
+			$respHeader = $response['body']['res-hdr']['HTTP_STATUS'] ?? '';
+			if (\strpos($respHeader, '403 Forbidden') !== false || \strpos($respHeader, '403 VirusFound') !== false) {
+				return [Status::SCANRESULT_INFECTED];
+			}
+			return [Status::SCANRESULT_CLEAN];
+		}
+
+		return null;
+	}
+}

--- a/lib/Scanner/ICAPScanner.php
+++ b/lib/Scanner/ICAPScanner.php
@@ -32,10 +32,6 @@ class ICAPScanner implements IScanner {
 	 */
 	private $reqService;
 	/**
-	 * @var string
-	 */
-	private $virusHeader;
-	/**
 	 * @var int
 	 */
 	private $sizeLimit;
@@ -47,15 +43,17 @@ class ICAPScanner implements IScanner {
 	 * @var ILogger
 	 */
 	private $logger;
+	/** @var ICAPResponseAnalyser */
+	private $analyser;
 
 	public function __construct(AppConfig $config, ILogger $logger, IL10N $l10n) {
 		$this->host = $config->getAvHost();
 		$this->port = $config->getAvPort();
 		$this->reqService = $config->getAvRequestService();
-		$this->virusHeader = $config->getAvResponseHeader();
 		$this->sizeLimit = $config->getAvMaxFileSize();
 		$this->l10n = $l10n;
 		$this->logger = $logger;
+		$this->analyser = new ICAPResponseAnalyser($config->getAvResponseHeader());
 	}
 
 	public function initScanner(string $fileName): void {
@@ -102,21 +100,11 @@ class ICAPScanner implements IScanner {
 					$icapHeaders
 				);
 			}
-			$code = $response['protocol']['code'] ?? 500;
-			if ($code === 100 || $code === 200 || $code === 204) {
-				// c-icap/clamav reports this header - McAfee 11 reports the virus name in `res-hdr`
-				$virus = $response['headers'][$this->virusHeader] ?? $response['res-hdr'][$this->virusHeader] ?? false;
-				if ($virus) {
-					return Status::create(Status::SCANRESULT_INFECTED, $virus);
-				}
 
-				// kaspersky(pre-2020 product editions) and McAfee handling
-				$respHeader = $response['body']['res-hdr']['HTTP_STATUS'] ?? '';
-				if (\strpos($respHeader, '403 Forbidden') !== false || \strpos($respHeader, '403 VirusFound') !== false) {
-					$message = $this->l10n->t('A malware or virus was detected, your upload was denied. In doubt or for details please contact your system administrator.');
-					return Status::create(Status::SCANRESULT_INFECTED, $message);
-				}
-				return Status::create(Status::SCANRESULT_CLEAN);
+			$status = $this->analyser->analyseResponse($response);
+			if ($status) {
+				$message = $this->l10n->t('A malware or virus was detected, your upload was denied. In doubt or for details please contact your system administrator.');
+				return Status::create($status[0], $status[1] ?? $message);
 			}
 			$respJson = json_encode($response, JSON_THROW_ON_ERROR);
 			$this->logger->error("ICAP response unusable: $respJson");

--- a/lib/Scanner/ICAPScanner.php
+++ b/lib/Scanner/ICAPScanner.php
@@ -104,8 +104,8 @@ class ICAPScanner implements IScanner {
 			}
 			$code = $response['protocol']['code'] ?? 500;
 			if ($code === 100 || $code === 200 || $code === 204) {
-				// c-icap/clamav reports this header
-				$virus = $response['headers'][$this->virusHeader] ?? false;
+				// c-icap/clamav reports this header - McAfee 11 reports the virus name in `res-hdr`
+				$virus = $response['headers'][$this->virusHeader] ?? $response['res-hdr'][$this->virusHeader] ?? false;
 				if ($virus) {
 					return Status::create(Status::SCANRESULT_INFECTED, $virus);
 				}

--- a/lib/Scanner/McAfeeWebGatewayScanner.php
+++ b/lib/Scanner/McAfeeWebGatewayScanner.php
@@ -22,7 +22,6 @@ class McAfeeWebGatewayScanner extends ICAPScanner {
 	protected function getICAPHeaders(): array {
 		$localIP = getHostByName(getHostName());
 		return [
-			'Preview' => $this->getContentLength(),
 			'X-Client-IP' => $localIP,
 			'Allow' => 204
 		];

--- a/tests/unit/Scanner/ICAPResponseTest.php
+++ b/tests/unit/Scanner/ICAPResponseTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OCA\Files_Antivirus\Tests\unit\Scanner;
+
+use Generator;
+use JsonException;
+use OCA\Files_Antivirus\Scanner\ICAPResponseAnalyser;
+use OCA\Files_Antivirus\Status;
+use Test\TestCase;
+
+class ICAPResponseTest extends TestCase {
+	/**
+	 * @dataProvider providesScanData
+	 * @throws JsonException
+	 */
+	public function test(?int $expectedStatus, ?string $expectedVirusName, string $response): void {
+		$response = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+		$analyser = new ICAPResponseAnalyser('X-Virus-Name');
+		$status = $analyser->analyseResponse($response);
+
+		self::assertEquals($expectedStatus, $status[0]);
+		self::assertEquals($expectedVirusName, $status[1] ?? null);
+	}
+
+	public function providesScanData(): Generator {
+		yield 'McAfee 11' => [Status::SCANRESULT_INFECTED, 'EICAR test file', '{"protocol":{"protocolVersion":"1.0","code":100,"status":"Continue"},"headers":{"ISTag":"\"008040-000000-10698-116696-00\"","ICAP\\\/1.0 200 OK":"","Encapsulated":"res-hdr=0, res-body=121"},"body":{"res-hdr":{"HTTP_STATUS":"X-Media-Type: text\\\/plain","X-Media-Type":"text\\\/plain","X-Virus-Name":"EICAR test file","X-Block-Reason":"Malware found","X-WWBlockResult":"80","HTTP\\\/1.1 4":""}}}'];
+		yield 'McAfee 10' => [Status::SCANRESULT_INFECTED, null, '{"protocol":{"protocolVersion":"1.0","code":200,"status":"OK"},"headers":{"ISTag":"\\"00007468-8.39.102-00010079\\"","Encapsulated":"res-hdr=0, res-body=114"},"body":{"res-hdr":{"HTTP_STATUS":"403 VirusFound"," 403 VirusFound":"","Content-Type":"text\\\/html","Cache-Control":"no-cache","Content-Length":"2682","X-Frame-Options":"deny"}}}'];
+	}
+}


### PR DESCRIPTION
…esponse code, which we never implemented properly

## Background

In preview mode McAffee is responding with status code 100 which results in McAffee to wait for more data to be sent by ownCloud. But we have not more data to send - and `100` handling was never properly implemented.

As a result `Preview` is removed from the McAffee implementation of ICAP scanner & client. 


fixes https://github.com/owncloud/enterprise/issues/5588