### PR TITLE
fix: drop usage of ${}

### DIFF
--- a/appinfo/Migrations/Version20170808221437.php
+++ b/appinfo/Migrations/Version20170808221437.php
@@ -32,7 +32,7 @@ class Version20170808221437 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}files_antivirus")) {
+		if ($schema->hasTable("{$prefix}files_antivirus")) {
 			$table = $schema->getTable("{$prefix}files_antivirus");
 
 			$fileIdColumn = $table->getColumn('fileid');

--- a/appinfo/Migrations/Version20210212160142.php
+++ b/appinfo/Migrations/Version20210212160142.php
@@ -33,8 +33,8 @@ class Version20210212160142 implements ISchemaMigration {
 		$prefix = $options['tablePrefix'];
 
 		if (
-			$schema->hasTable("${prefix}files_antivirus_status")
-			&& $schema->hasTable("${prefix}files_avir_status") === false
+			$schema->hasTable("{$prefix}files_antivirus_status")
+			&& $schema->hasTable("{$prefix}files_avir_status") === false
 		) {
 			$dbConn = \OC::$server->getDatabaseConnection();
 			$alterQuery = $dbConn->prepare(


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995
