### PR TITLE
[full-ci] [tests-only] Changed rocketchat notifications server  to 

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -57,7 +57,7 @@ dir = {
 config = {
     "rocketchat": {
         "channel": "builds",
-        "from_secret": "rocketchat_chat_webhook",
+        "from_secret": "rocketchat_talk_webhook",
     },
     "branches": [
         "master",


### PR DESCRIPTION
This PR change the rocketchat notification server `chat` to `talk`.

Part of https://github.com/owncloud/QA/issues/846
